### PR TITLE
Check deploy message responses for string errors

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/amazeeio/lagoon-cli/internal/lagoon"
 	"github.com/amazeeio/lagoon-cli/internal/lagoon/client"
@@ -53,7 +54,11 @@ use 'lagoon deploy latest' instead`,
 			if err != nil {
 				return err
 			}
-			fmt.Println(result.DeployEnvironmentBranch)
+			response := result.DeployEnvironmentBranch
+			if strings.HasPrefix(response, "Error: ") {
+				return fmt.Errorf(strings.Trim(response, "Error: "))
+			}
+			fmt.Println(response)
 		}
 		return nil
 	},
@@ -99,7 +104,11 @@ var deployPromoteCmd = &cobra.Command{
 			if err != nil {
 				return err
 			}
-			fmt.Println(result.DeployEnvironmentPromote)
+			response := result.DeployEnvironmentPromote
+			if strings.HasPrefix(response, "Error: ") {
+				return fmt.Errorf(strings.Trim(response, "Error: "))
+			}
+			fmt.Println(response)
 		}
 		return nil
 	},
@@ -142,7 +151,11 @@ This environment should already exist in lagoon. It is analogous with the 'Deplo
 			if err != nil {
 				return err
 			}
-			fmt.Println(result.DeployEnvironmentLatest)
+			response := result.DeployEnvironmentLatest
+			if strings.HasPrefix(response, "Error: ") {
+				return fmt.Errorf(strings.Trim(response, "Error: "))
+			}
+			fmt.Println(response)
 		}
 		return nil
 	},
@@ -214,7 +227,11 @@ This pullrequest may not already exist as an environment in lagoon.`,
 			if err != nil {
 				return err
 			}
-			fmt.Println(result.DeployEnvironmentPullrequest)
+			response := result.DeployEnvironmentPullrequest
+			if strings.HasPrefix(response, "Error: ") {
+				return fmt.Errorf(strings.Trim(response, "Error: "))
+			}
+			fmt.Println(response)
 		}
 		return nil
 	},


### PR DESCRIPTION

 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->
 
<!-- You can skip this if you're fixing a typo. -->
# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated.
- [ ] Changelog entry has been written

The Lagoon API sends a string result even for some errors when triggering deployments using any of the `deployX` mutations. This PR adds a check to check for `Error:` in the response and makes the CLI use an actual error exit code instead of `0`.

# Changelog Entry
<!--
Describe the change in order to make it visible in the changelog
If the change breaks anything document this - how was the functionality before - how does it work after the change

Prefix the change with: Feature, Change, Bugfix, Improvement, Documentation

Use following format:
Improvement - Description (#ISSUENUMBER)
-->

# Closing issues
closes #189 
