### PR TITLE
add goreleaser action

### DIFF
--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -1,0 +1,64 @@
+name: goreleaser action
+
+on:
+  push:
+    tags:
+      - 'v*'
+  pull_request:
+
+jobs:
+  test-suite:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        goversion:
+        - 1.16
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: "0"
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.goversion}}
+    - name: Build
+      run: |
+        go get github.com/golang/mock/mockgen@v1.4.3
+        go get -u github.com/go-bindata/go-bindata/...
+        ARTIFACT_DESTINATION=./builds make build
+    # - name: Check version
+    #   run: |
+    #     ./builds/lagoon --version
+
+  goreleaser:
+    needs: test-suite
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        goversion:
+        - 1.16
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: "0"
+      -
+        name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{matrix.goversion}}
+      -
+        name: Fetch Dependencies
+        run: go mod download
+      -
+        name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: release --debug --skip-validate
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_ACTION_PAT }}
+          GOVERSION: ${{ matrix.goversion }}
+          LOCAL_ORG: ${{ github.repository_owner }}

--- a/.github/workflows/lagoon-cli.yaml
+++ b/.github/workflows/lagoon-cli.yaml
@@ -2,8 +2,6 @@ name: Lagoon CLI Test
 
 on:
   push:
-    branches:
-      - '**'
     tags:
       - 'v*.*.*'
   pull_request:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -72,6 +72,11 @@ archives:
     name_template: "{{ .ProjectName }}-v{{ .Version }}-{{ .Os }}-{{ .Arch }}"
     wrap_in_directory: true
 
+source:
+  enabled: true
+  format: 'tar.gz'
+  name_template: "{{ .ProjectName }}-v{{ .Version }}-source"
+
 checksum:
   name_template: 'checksums.txt'
   algorithm: sha256

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,101 @@
+env:
+  - GO111MODULE=on
+  - GOPROXY=https://gocenter.io
+  - LOCAL_ORG={{ .Env.LOCAL_ORG }}
+
+builds:
+  - id: lagoon
+    binary: lagoon
+    env:
+      - CGO_ENABLED=0
+      - GO111MODULE=on
+    # Custom ldflags templates.
+    # Default is `-s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}} -X main.builtBy=goreleaser`.
+    ldflags:
+      - -s -w -X github.com/uselagoon/lagoon-cli/cmd.lagoonCLIVersion=v{{ .Version }}
+        -X github.com/uselagoon/lagoon-cli/cmd.lagoonCLIBuild={{ .Date }}
+        -X github.com/uselagoon/lagoon-cli/cmd.lagoonCLIBuildGoVersion=go-{{ .Env.GOVERSION }}
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+
+# universal_binaries:
+# - id: lagoon
+#   name_template: lagoon
+#   replace: true
+
+release:
+  # Repo in which the release will be created.
+  # Default is extracted from the origin remote URL or empty if its private hosted.
+  header: |
+    ## Lagoon CLI (v{{.Version}})
+    ### Installation via Brew
+    The preferred method is installation via [Homebrew](https://brew.sh/).
+    ```
+    brew tap {{ .Env.LOCAL_ORG }}/lagoon-cli
+    brew install lagoon
+    ```
+    ### Running from released binaries
+    Alternatively, you may install by downloading one of the pre-compiled binaries (replace `amd64` with `arm64` for ARM-compatible binaries)
+    ```
+    # MacOS
+    sudo curl -L "https://github.com/{{ .Env.LOCAL_ORG }}/lagoon-cli/releases/download/v{{.Version}}/lagoon-cli-v{{.Version}}-darwin-amd64" -o /usr/local/bin/lagoon && sudo chmod +x /usr/local/bin/lagoon
+    # Linux
+    sudo curl -L "https://github.com/{{ .Env.LOCAL_ORG }}/lagoon-cli/releases/download/v{{.Version}}/lagoon-cli-v{{.Version}}-linux-amd64" -o /usr/local/bin/lagoon && sudo chmod +x /usr/local/bin/lagoon
+    ```
+    ### Running from a Dockerfile
+    Alternatively, you may download the latest release as a Dockerfile from [GitHub](https://github.com/{{ .Env.LOCAL_ORG }}/lagoon-cli/pkgs/container/lagoon-cli) or [Docker Hub](https://hub.docker.com/r/{{ .Env.LOCAL_ORG }}/lagoon-cli)
+    See the [docs](https://uselagoon.github.io/lagoon-cli/#running_as_a_docker_image) for information on running as a Dockerfile
+    ```
+    docker pull ghcr.io/{{ .Env.LOCAL_ORG }}/lagoon-cli:v{{.Version}}
+    docker pull docker.io/{{ .Env.LOCAL_ORG }}/lagoon-cli:v{{.Version}}
+    ```
+  # Defaults to empty.
+  name_template: "{{.ProjectName}}-v{{.Version}}"
+
+archives:
+  - id: binaries
+    builds:
+    - lagoon
+    format: binary
+    name_template: "{{ .ProjectName }}-v{{ .Version }}-{{ .Os }}-{{ .Arch }}"
+    wrap_in_directory: true
+    files:
+      - none*
+  - id: binaries-targz
+    builds:
+      - lagoon
+    format: tar.gz
+    name_template: "{{ .ProjectName }}-v{{ .Version }}-{{ .Os }}-{{ .Arch }}"
+    wrap_in_directory: true
+
+checksum:
+  name_template: 'checksums.txt'
+  algorithm: sha256
+
+  # signs:
+#   - artifacts: checksum
+#     args: ["--batch", "-u", "{{ .Env.GPG_FINGERPRINT }}", "--output", "${signature}", "--detach-sign", "${artifact}"]
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+
+brews:
+  - name: lagoon
+    tap:
+      owner: "{{ .Env.LOCAL_ORG }}"
+      name: homebrew-lagoon-cli
+    homepage: "https://github.com/{{ .Env.LOCAL_ORG }}/lagoon-cli"
+    description: "Lagoon's local development helper tool"
+    skip_upload: false
+    test: system "#{bin}/lagoon version"
+    install: bin.install "lagoon"
+    ids:
+      - binaries-targz

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ PKGMODPATH=$(DIR)/vendor
 VERSION=$(shell echo $(shell git describe --abbrev=0 --tags)+$(shell git rev-parse --short=8 HEAD))
 BUILD=$(shell date +%FT%T%z)
 
-DOCKER_GO_VER=1.14
+DOCKER_GO_VER=1.16
 GO_VER=$(shell go version)
 LDFLAGS=-w -s -X ${PKG}/cmd.lagoonCLIVersion=${VERSION} -X ${PKG}/cmd.lagoonCLIBuild=${BUILD}
 


### PR DESCRIPTION
This PR configures goreleaser for use with this repo.

It will:
* Add a Homebrew release at uselagoon/lagoon-CLI (Linux/macOS + amd64/arm64 compatible)
* Publish the binaries and tar.gz to a GitHub release, with a checksum file
* Add a changelog
* Format the release note (sample in a comment below)
* Also work in a forked repo - the releases, brew etc will push to the fork in the event of a tag - so you can self-publish pre-releases etc safely

I've added an extra secret GH_ACTION_PAT that will need refreshing
I've disabled the `releaser` action, for now, we can remove it later