### PR TITLE
add URL to generated sitemap and Google Analytics

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,6 +8,10 @@ theme:
   favicon: lagoon-cli-logo.png
   icon:
     logo: fontawesome/solid/terminal
+extra:
+  analytics:
+    provider: google
+    property: G-W1SJFEVFDB
 markdown_extensions:
   - codehilite
   - admonition


### PR DESCRIPTION
The sitemap.xml for the documentation doesn't contain any URLs and is therefore skipped by google search
![image](https://user-images.githubusercontent.com/4373945/136111835-bf35cd34-29f0-4ae0-890f-365163d08767.png)

Adding the canonical URL to the config fixes this
![image](https://user-images.githubusercontent.com/4373945/136112187-655e181f-6587-4aa8-8a1e-09c4fa3dc2b5.png)

As I pushed to the `docs` branch, this has already deployed