### PR TITLE
Allowing json string flag to be used when updating a project

### DIFF
--- a/cmd/project.go
+++ b/cmd/project.go
@@ -101,8 +101,15 @@ var updateProjectCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		jsonPatch, _ := json.Marshal(projectFlags)
-		projectUpdateID, err := pClient.UpdateProject(cmdProjectName, string(jsonPatch))
+		var jsonPatchFromProjectFlags string
+		if string(jsonPatch) != "" {
+			jsonPatchFromProjectFlags = jsonPatch
+		} else {
+			jsonMarshalPatch, _ := json.Marshal(projectFlags)
+			jsonPatchFromProjectFlags = string(jsonMarshalPatch)
+		}
+
+		projectUpdateID, err := pClient.UpdateProject(cmdProjectName, jsonPatchFromProjectFlags)
 		handleError(err)
 		var updatedProject api.Project
 		err = json.Unmarshal([]byte(projectUpdateID), &updatedProject)

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -249,6 +249,7 @@ type Project struct {
 	Environments                 []Environment         `json:"environments,omitempty"`
 	Deployments                  []Deployment          `json:"deployments,omitempty"`
 	Notifications                []interface{}         `json:"notifications,omitempty"`
+	FactsUI                      *int                  `json:"factsUi,omitempty"`
 }
 
 // ProjectPatch struct.
@@ -273,6 +274,7 @@ type ProjectPatch struct {
 	OpenshiftProjectPattern      string `json:"openshiftProjectPattern,omitempty"`
 	DevelopmentEnvironmentsLimit *int   `json:"developmentEnvironmentsLimit,omitempty"`
 	Openshift                    *int   `json:"openshift,omitempty"`
+	FactsUI                      *int   `json:"factsUi,omitempty"`
 }
 
 // AddSSHKey .

--- a/pkg/lagoon/projects/main.go
+++ b/pkg/lagoon/projects/main.go
@@ -274,7 +274,7 @@ func processProjectUpdate(projectByName []byte, jsonPatch string) (api.UpdatePro
 	var projects api.Project
 	var projectUpdate api.UpdateProject
 	var project api.ProjectPatch
-	err := json.Unmarshal([]byte(projectByName), &projects)
+	err := json.Unmarshal(projectByName, &projects)
 	if err != nil {
 		return projectUpdate, err
 	}


### PR DESCRIPTION
closes #222 

Can now also update FactsUI bool

```
> go run main.go -l amazeeio update project -p example-drupalcon-portland-2022 -j "{ \"factsUi\": 1 }"
Result: success
Project Name: example-drupalcon-portland-2022
```