### PR TITLE
feat: support lagoon environment name in ssh

### DIFF
--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -1,0 +1,34 @@
+package cmd
+
+import (
+	"crypto/sha1"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// makeSafe ensures that any string is dns safe
+func makeSafe(in string) string {
+	out := regexp.MustCompile(`[^0-9a-z-]`).ReplaceAllString(
+		strings.ToLower(in),
+		"$1-$2",
+	)
+	return out
+}
+
+// shortenEnvironment shortens the environment name down the same way that Lagoon does
+func shortenEnvironment(project, environment string) string {
+	overlength := 58 - len(project)
+	if len(environment) > overlength {
+		environment = fmt.Sprintf("%s-%s", environment[0:overlength-5], hashString(environment)[0:4])
+	}
+	return environment
+}
+
+// hashString get the hash of a given string.
+func hashString(s string) string {
+	h := sha1.New()
+	h.Write([]byte(s))
+	bs := h.Sum(nil)
+	return fmt.Sprintf("%x", bs)
+}

--- a/cmd/helpers_test.go
+++ b/cmd/helpers_test.go
@@ -1,0 +1,94 @@
+package cmd
+
+import "testing"
+
+func Test_makeSafe(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "slash in name",
+			in:   "Feature/Branch",
+			want: "feature-branch",
+		},
+		{
+			name: "noslash in name",
+			in:   "Feature-Branch",
+			want: "feature-branch",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := makeSafe(tt.in); got != tt.want {
+				t.Errorf("makeSafe() go %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_hashString(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "generate hash",
+			in:   "feature-branch",
+			want: "011122006d017c21d1376add9f7f65b43555a455",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hashString(tt.in); got != tt.want {
+				t.Errorf("hashString() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_shortenEnvironment(t *testing.T) {
+	type args struct {
+		project     string
+		environment string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "really long environment name with slash and capitals",
+			args: args{
+				environment: makeSafe("Feature/Really-Exceedingly-Long-Environment-Name-For-A-Branch"),
+				project:     "this-is-my-project",
+			},
+			want: "feature-really-exceedingly-long-env-dc8c",
+		},
+		{
+			name: "short environment name",
+			args: args{
+				environment: makeSafe("Feature/Branch"),
+				project:     "this-is-my-project",
+			},
+			want: "feature-branch",
+		},
+		{
+			name: "short environment name",
+			args: args{
+				environment: makeSafe("release/1.2.3"),
+				project:     "this-is-my-project",
+			},
+			want: "release-1-2-3",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shortenEnvironment(tt.args.project, tt.args.environment); got != tt.want {
+				t.Errorf("shortenEnvironment() got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -26,6 +26,12 @@ var sshEnvCmd = &cobra.Command{
 			cmd.Help()
 			os.Exit(1)
 		}
+
+		// allow the use of the `feature/branch` and standard `feature-branch` type environment names to be used
+		// since ssh requires the `feature-branch` type name to be used as the ssh username
+		// run the environment through the makesafe and shorted functions that lagoon uses
+		environmentName := makeSafe(shortenEnvironment(cmdProjectName, cmdProjectEnvironment))
+
 		// get private key that the cli is using
 		skipAgent := false
 
@@ -43,7 +49,7 @@ var sshEnvCmd = &cobra.Command{
 		sshConfig := map[string]string{
 			"hostname": lagoonCLIConfig.Lagoons[lagoonCLIConfig.Current].HostName,
 			"port":     lagoonCLIConfig.Lagoons[lagoonCLIConfig.Current].Port,
-			"username": cmdProjectName + "-" + cmdProjectEnvironment,
+			"username": cmdProjectName + "-" + environmentName,
 			"sshkey":   privateKey,
 		}
 		if sshConnString {


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->
 
<!-- You can skip this if you're fixing a typo. -->
# Checklist
- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated.
- [ ] Changelog entry has been written

The current implementation of ssh requires the user to use the version of the environment name that is dns compliant as this is how SSH in Lagoon works, like `feature-branch`. All other commands in Lagoon require the environment name as it is used, like `feature/branch`.

This PR brings support for the format of environment name that all other commands in the CLI use. Using the `feature-branch` style environment name is still supported too.

# Changelog Entry
<!--
Describe the change in order to make it visible in the changelog
If the change breaks anything document this - how was the functionality before - how does it work after the change

Prefix the change with: Feature, Change, Bugfix, Improvement, Documentation

Use following format:
Improvement - Description (#ISSUENUMBER)
-->

# Closing issues
closes #147 
