### PR TITLE
chore: only push to gh-pages on tags

### DIFF
--- a/.github/workflows/lagoon-cli.yaml
+++ b/.github/workflows/lagoon-cli.yaml
@@ -2,6 +2,8 @@ name: Lagoon CLI Test
 
 on:
   push:
+    branches:
+      - main
     tags:
       - 'v*.*.*'
   pull_request:

--- a/.github/workflows/mkdocs.yaml
+++ b/.github/workflows/mkdocs.yaml
@@ -1,9 +1,8 @@
 name: Publish docs via GitHub Pages
 on:
   push:
-    branches:
-      - main
-      - mkdocs
+    tags:
+      - 'v*.*.*'
 
 jobs:
   build:


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->
 
<!-- You can skip this if you're fixing a typo. -->
# Checklist
- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated.
- [ ] Changelog entry has been written

Just some updates to which actions run when. Pushing to gh-pages for documentation updates should only be done when a tag is released.

Tests should run when any code is merged to main

# Changelog Entry
<!--
Describe the change in order to make it visible in the changelog
If the change breaks anything document this - how was the functionality before - how does it work after the change

Prefix the change with: Feature, Change, Bugfix, Improvement, Documentation

Use following format:
Improvement - Description (#ISSUENUMBER)
-->
