### PR TITLE
Update to change default lagoon command documentation

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -56,7 +56,7 @@ lagoon config default
 ```
 ## Example
 ```bash
-lagoon config default amazeeio
+lagoon config default --lagoon amazeeio
 ```
 
 # Use a different Lagoon


### PR DESCRIPTION
The existing documentation states that you can change the default lagoon and provides an example of such:

```
lagoon config default amazeeio
```

Attempting to enact a change to the default lagoon by following the documentation results in a failure with the message:

```
Not enough arguments
Set the default Lagoon to use
```
It is actually required that we add another flag in order for the command to execute successfully, that being the --lagoon flag as follows:

```
lagoon config default --lagoon amazeeio
```

With the flag set, it will now complete the change and report success which can be confirmed by listing your default lagoon.

@AlannaBurke tagged as per contribution guidelines.

 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->
 
<!-- You can skip this if you're fixing a typo. -->
# Checklist
- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated.
- [ ] Changelog entry has been written

Explain the **details** for making this change. What existing problem does the pull request solve?

# Changelog Entry
<!--
Describe the change in order to make it visible in the changelog
If the change breaks anything document this - how was the functionality before - how does it work after the change

Prefix the change with: Feature, Change, Bugfix, Improvement, Documentation

Use following format:
Improvement - Description (#ISSUENUMBER)
-->

# Closing issues
Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
