### PR TITLE
change: Remove deprecated MonitoringURLs

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -650,7 +650,6 @@ type Environment struct {
 	Deleted              string                `json:"deleted,omitempty"`
 	Route                string                `json:"route,omitempty"`
 	Routes               string                `json:"routes,omitempty"`
-	MonitoringUrls       string                `json:"monitoringUrls,omitempty"`
 	EnvVariables         []EnvironmentVariable `json:"envVariables,omitempty"`
 	Backups              []Backup              `json:"backups,omitempty"`
 	Tasks                []Task                `json:"tasks,omitempty"`

--- a/pkg/lagoon/environments/main.go
+++ b/pkg/lagoon/environments/main.go
@@ -132,7 +132,7 @@ func processEnvInfo(projectByName []byte) ([]byte, error) {
 	var data []output.Data
 	data = append(data, environmentData)
 	dataMain := output.Table{
-		Header: []string{"ID", "EnvironmentName", "EnvironmentType", "DeployType", "Created", "OpenshiftProjectName", "Route", "Routes", "MonitoringURLS", "AutoIdle", "DeployTitle", "DeployBaseRef", "DeployHeadRef"},
+		Header: []string{"ID", "EnvironmentName", "EnvironmentType", "DeployType", "Created", "OpenshiftProjectName", "Route", "Routes", "AutoIdle", "DeployTitle", "DeployBaseRef", "DeployHeadRef"},
 		Data:   data,
 	}
 	return json.Marshal(dataMain)
@@ -160,7 +160,6 @@ func processEnvExtra(environment api.Environment) []string {
 		fmt.Sprintf("%v", envOpenshiftProjectName),
 		fmt.Sprintf("%v", envRoute),
 		fmt.Sprintf("%v", envRoutes),
-		fmt.Sprintf("%v", "-"), // MonitoringURLS is deprecated, don't query this data
 		fmt.Sprintf("%v", envAutoIdle),
 		fmt.Sprintf("%v", envDeployTitle),
 		fmt.Sprintf("%v", envDeployBaseRef),

--- a/pkg/lagoon/environments/main_test.go
+++ b/pkg/lagoon/environments/main_test.go
@@ -19,7 +19,7 @@ func checkEqual(t *testing.T, got, want interface{}, msgs ...interface{}) {
 
 func TestGetEnvironmentByName(t *testing.T) {
 	var all = `{"autoIdle":1,"created":"2019-10-29 04:26:11","deleted":"0000-00-00 00:00:00","deployBaseRef":"Master","deployHeadRef":null,"deployTitle":null,"deployType":"branch","environmentType":"production","id":3,"name":"Master","openshiftProjectName":"high-cotton-master","route":"http://highcotton.org","routes":"http://highcotton.org,https://varnish-highcotton-org-prod.us.amazee.io,https://nginx-highcotton-org-prod.us.amazee.io","updated":"2019-10-29 04:26:43"}`
-	var allSuccess = `{"header":["ID","EnvironmentName","EnvironmentType","DeployType","Created","OpenshiftProjectName","Route","Routes","MonitoringURLS","AutoIdle","DeployTitle","DeployBaseRef","DeployHeadRef"],"data":[["3","Master","production","branch","2019-10-29 04:26:11","high-cotton-master","http://highcotton.org","http://highcotton.org,https://varnish-highcotton-org-prod.us.amazee.io,https://nginx-highcotton-org-prod.us.amazee.io","-","1","-","Master","-"]]}`
+	var allSuccess = `{"header":["ID","EnvironmentName","EnvironmentType","DeployType","Created","OpenshiftProjectName","Route","Routes","AutoIdle","DeployTitle","DeployBaseRef","DeployHeadRef"],"data":[["3","Master","production","branch","2019-10-29 04:26:11","high-cotton-master","http://highcotton.org","http://highcotton.org,https://varnish-highcotton-org-prod.us.amazee.io,https://nginx-highcotton-org-prod.us.amazee.io","1","-","Master","-"]]}`
 
 	testResult, err := processEnvInfo([]byte(all))
 	if err != nil {


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->
 
<!-- You can skip this if you're fixing a typo. -->
# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated.
- [x] Changelog entry has been written

Follow up from #259. Missed a field on the `Environment` struct. Also it was discussed that we can fully remove this since it's not used (and it's been broken for a couple years) and we don't have a BC break policy that would prevent it.

# Closing issues
n/a
