### PR TITLE
fix: update metadata to use map for json response

### DIFF
--- a/cmd/project.go
+++ b/cmd/project.go
@@ -178,7 +178,8 @@ var listProjectByMetadata = &cobra.Command{
 				returnNonEmptyString(fmt.Sprintf("%v", project.Name)),
 			}
 			if showMetadata {
-				projectData = append(projectData, returnNonEmptyString(fmt.Sprintf("%v", project.Metadata)))
+				metaData, _ := json.Marshal(project.Metadata)
+				projectData = append(projectData, returnNonEmptyString(fmt.Sprintf("%v", string(metaData))))
 			}
 			data = append(data, projectData)
 		}
@@ -225,14 +226,12 @@ var getProjectMetadata = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		if project.Metadata == "{}" {
+		if len(project.Metadata) == 0 {
 			output.RenderInfo(fmt.Sprintf("There is no metadata for project '%s'", cmdProjectName), outputOptions)
 			return nil
 		}
-		metadataResponse := map[string]string{}
-		json.Unmarshal([]byte(project.Metadata), &metadataResponse)
 		data := []output.Data{}
-		for metaKey, metaVal := range metadataResponse {
+		for metaKey, metaVal := range project.Metadata {
 			metadataData := []string{
 				returnNonEmptyString(fmt.Sprintf("%v", metaKey)),
 				returnNonEmptyString(fmt.Sprintf("%v", metaVal)),
@@ -291,10 +290,11 @@ var updateProjectMetadata = &cobra.Command{
 				return err
 			}
 			data := []output.Data{}
+			metaData, _ := json.Marshal(projectResult.Metadata)
 			data = append(data, []string{
 				returnNonEmptyString(fmt.Sprintf("%v", projectResult.ID)),
 				returnNonEmptyString(fmt.Sprintf("%v", projectResult.Name)),
-				returnNonEmptyString(fmt.Sprintf("%v", projectResult.Metadata)),
+				returnNonEmptyString(fmt.Sprintf("%v", string(metaData))),
 			})
 			output.RenderOutput(output.Table{
 				Header: []string{
@@ -345,10 +345,11 @@ var deleteProjectMetadataByKey = &cobra.Command{
 				return err
 			}
 			data := []output.Data{}
+			metaData, _ := json.Marshal(projectResult.Metadata)
 			data = append(data, []string{
 				returnNonEmptyString(fmt.Sprintf("%v", projectResult.ID)),
 				returnNonEmptyString(fmt.Sprintf("%v", projectResult.Name)),
-				returnNonEmptyString(fmt.Sprintf("%v", projectResult.Metadata)),
+				returnNonEmptyString(fmt.Sprintf("%v", string(metaData))),
 			})
 			output.RenderOutput(output.Table{
 				Header: []string{

--- a/internal/schema/project.go
+++ b/internal/schema/project.go
@@ -88,5 +88,5 @@ type AddNotificationToProjectInput struct {
 // ProjectMetadata .
 type ProjectMetadata struct {
 	Project
-	Metadata string `json:"metadata"`
+	Metadata map[string]string `json:"metadata"`
 }


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->
 
<!-- You can skip this if you're fixing a typo. -->
# Checklist
- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated.
- [ ] Changelog entry has been written

Lagoon v2.12.0 contains a change in the response field for metadata. A mariadb update resulted in the data that was previously returned as an escaped string now returns as valid json.

The Lagoon CLI used to process this field as a string, now it returns as a map and processed using JSON utils.

# Changelog Entry
<!--
Describe the change in order to make it visible in the changelog
If the change breaks anything document this - how was the functionality before - how does it work after the change

Prefix the change with: Feature, Change, Bugfix, Improvement, Documentation

Use following format:
Improvement - Description (#ISSUENUMBER)
-->
Fix - Handle metadata properly

# Closing issues
closes #266 
