### PR TITLE
fix: add exit for ssh commands that exit

### DIFF
--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/uselagoon/lagoon-cli/internal/lagoon"
@@ -108,6 +109,7 @@ var sshEnvCmd = &cobra.Command{
 			}
 			if err != nil {
 				output.RenderError(err.Error(), outputOptions)
+				os.Exit(1)
 			}
 		}
 		return nil


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->
 
<!-- You can skip this if you're fixing a typo. -->
# Checklist
- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated.
- [ ] Changelog entry has been written

Fix if the ssh command exits to actually exit with 1

# Changelog Entry
<!--
Describe the change in order to make it visible in the changelog
If the change breaks anything document this - how was the functionality before - how does it work after the change

Prefix the change with: Feature, Change, Bugfix, Improvement, Documentation

Use following format:
Improvement - Description (#ISSUENUMBER)
-->

# Closing issues
closes #277 
