### PR TITLE
 Change: Updates the output from an `Error` to `Stderr` when listing variables where none are set

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -290,13 +290,6 @@ var listVariablesCmd = &cobra.Command{
 			}
 			data = append(data, env)
 		}
-		if len(data) == 0 {
-			if cmdProjectEnvironment != "" {
-				return fmt.Errorf("There are no variables for environment '%s' in project '%s'", cmdProjectEnvironment, cmdProjectName)
-			} else {
-				return fmt.Errorf("There are no variables for project '%s'", cmdProjectName)
-			}
-		}
 		header := []string{
 			"ID",
 			"Project",
@@ -308,6 +301,13 @@ var listVariablesCmd = &cobra.Command{
 		header = append(header, "Name")
 		if reveal {
 			header = append(header, "Value")
+		}
+		if len(data) == 0 {
+			if cmdProjectEnvironment != "" {
+				outputOptions.Error = fmt.Sprintf("There are no variables for environment '%s' in project '%s'", cmdProjectEnvironment, cmdProjectName)
+			} else {
+				outputOptions.Error = fmt.Sprintf("There are no variables for project '%s'\n", cmdProjectName)
+			}
 		}
 		output.RenderOutput(output.Table{
 			Header: header,

--- a/pkg/output/main.go
+++ b/pkg/output/main.go
@@ -26,6 +26,7 @@ type Options struct {
 	JSON   bool
 	Pretty bool
 	Debug  bool
+	Error  string
 }
 
 // Result .
@@ -125,6 +126,9 @@ func RenderOutput(data Table, opts Options) {
 		RenderJSON(returnedData, opts)
 	} else {
 		// otherwise render a table
+		if opts.Error != "" {
+			os.Stdout.WriteString(opts.Error)
+		}
 		table := tablewriter.NewWriter(os.Stdout)
 		opts.Header = !opts.Header
 		if opts.Header {

--- a/pkg/output/main.go
+++ b/pkg/output/main.go
@@ -127,7 +127,7 @@ func RenderOutput(data Table, opts Options) {
 	} else {
 		// otherwise render a table
 		if opts.Error != "" {
-			os.Stdout.WriteString(opts.Error)
+			os.Stderr.WriteString(opts.Error)
 		}
 		table := tablewriter.NewWriter(os.Stdout)
 		opts.Header = !opts.Header


### PR DESCRIPTION
# Checklist
- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated.
- [ ] Changelog entry has been written

When running `list variables` on a project/environment where none exist an error is returned alongside the cli `Usage` text. Rather than returning an error, this updates the cmd to output the message via `Stderr` with an empty table (similar functionality to how the api currently operates) and doesn't unnecessarily display the `Usage` text. Also updates the `output` package to handle the error strings.