### PR TITLE
fix: if value of variable is empty, dont replace it with -

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -286,7 +286,7 @@ var listVariablesCmd = &cobra.Command{
 			env = append(env, returnNonEmptyString(fmt.Sprintf("%v", envvar.Scope)))
 			env = append(env, returnNonEmptyString(fmt.Sprintf("%v", envvar.Name)))
 			if reveal {
-				env = append(env, returnNonEmptyString(fmt.Sprintf("%v", envvar.Value)))
+				env = append(env, fmt.Sprintf("%v", envvar.Value))
 			}
 			data = append(data, env)
 		}


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->
 
<!-- You can skip this if you're fixing a typo. -->
# Checklist
- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated.
- [ ] Changelog entry has been written

Because the value is the last column, don't replace the returned value with `-` if the value in the API is actually empty

