### PR TITLE
fix: update delete email notification

### DIFF
--- a/cmd/notificationsemail.go
+++ b/cmd/notificationsemail.go
@@ -261,9 +261,9 @@ var deleteProjectEmailNotificationCmd = &cobra.Command{
 }
 
 var deleteEmailNotificationCmd = &cobra.Command{
-	Use:     "webhook",
-	Aliases: []string{"w"},
-	Short:   "Delete a email notification from Lagoon",
+	Use:     "email",
+	Aliases: []string{"e"},
+	Short:   "Delete an email notification from Lagoon",
 	PreRunE: func(_ *cobra.Command, _ []string) error {
 		return validateTokenE(lagoonCLIConfig.Current)
 	},

--- a/docs/commands/lagoon_delete_notification.md
+++ b/docs/commands/lagoon_delete_notification.md
@@ -32,6 +32,7 @@ Delete notifications or delete notifications from projects
 ### SEE ALSO
 
 * [lagoon delete](lagoon_delete.md)	 - Delete a project, or delete notifications and variables from projects or environments
+* [lagoon delete notification email](lagoon_delete_notification_email.md)	 - Delete an email notification from Lagoon
 * [lagoon delete notification microsoftteams](lagoon_delete_notification_microsoftteams.md)	 - Delete a Microsoft Teams notification from Lagoon
 * [lagoon delete notification project-email](lagoon_delete_notification_project-email.md)	 - Delete a email notification from a project
 * [lagoon delete notification project-microsoftteams](lagoon_delete_notification_project-microsoftteams.md)	 - Delete a Microsoft Teams notification from a project
@@ -40,6 +41,5 @@ Delete notifications or delete notifications from projects
 * [lagoon delete notification project-webhook](lagoon_delete_notification_project-webhook.md)	 - Delete a webhook notification from a project
 * [lagoon delete notification rocketchat](lagoon_delete_notification_rocketchat.md)	 - Delete a RocketChat notification from Lagoon
 * [lagoon delete notification slack](lagoon_delete_notification_slack.md)	 - Delete a Slack notification from Lagoon
-* [lagoon delete notification webhook](lagoon_delete_notification_webhook.md)	 - Delete a email notification from Lagoon
 * [lagoon delete notification webhook](lagoon_delete_notification_webhook.md)	 - Delete a webhook notification from Lagoon
 

--- a/docs/commands/lagoon_delete_notification_email.md
+++ b/docs/commands/lagoon_delete_notification_email.md
@@ -1,0 +1,40 @@
+## lagoon delete notification email
+
+Delete an email notification from Lagoon
+
+### Synopsis
+
+Delete an email notification from Lagoon
+
+```
+lagoon delete notification email [flags]
+```
+
+### Options
+
+```
+  -h, --help          help for email
+  -n, --name string   The name of the notification
+```
+
+### Options inherited from parent commands
+
+```
+      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
+      --debug                Enable debugging output (if supported)
+  -e, --environment string   Specify an environment to use
+      --force                Force yes on prompts (if supported)
+  -l, --lagoon string        The Lagoon instance to interact with
+      --no-header            No header on table (if supported)
+      --output-csv           Output as CSV (if supported)
+      --output-json          Output as JSON (if supported)
+      --pretty               Make JSON pretty (if supported)
+  -p, --project string       Specify a project to use
+      --skip-update-check    Skip checking for updates
+  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+```
+
+### SEE ALSO
+
+* [lagoon delete notification](lagoon_delete_notification.md)	 - Delete notifications or delete notifications from projects
+


### PR DESCRIPTION
Previously the delete email notification command was unusable because of a copy/pasta error from the delete webhook notifiction

```
tobybellwood@pop-os:~$ lagoon delete notification email -n example-email
Error: unknown shorthand flag: 'n' in -n
Usage:
  lagoon delete notification [command]

Aliases:
  notification, n

Available Commands:
  microsoftteams         Delete a Microsoft Teams notification from Lagoon
  project-email          Delete a email notification from a project
  project-microsoftteams Delete a Microsoft Teams notification from a project
  project-rocketchat     Delete a RocketChat notification from a project
  project-slack          Delete a Slack notification from a project
  project-webhook        Delete a webhook notification from a project
  rocketchat             Delete a RocketChat notification from Lagoon
  slack                  Delete a Slack notification from Lagoon
  webhook                Delete a email notification from Lagoon
  webhook                Delete a webhook notification from Lagoon
```

This PR fixes the email subcommand, and regens the correct docs.