### PR TITLE
refactor: use publicKey field to avoid permission errors on privateKey

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -232,6 +232,7 @@ type Project struct {
 	Name                         string                `json:"name,omitempty"`
 	GitURL                       string                `json:"gitUrl,omitempty"`
 	PrivateKey                   string                `json:"privateKey,omitempty"`
+	PublicKey                    string                `json:"publicKey,omitempty"`
 	Subfolder                    string                `json:"subfolder,omitempty"`
 	RouterPattern                string                `json:"routerPattern,omitempty"`
 	Branches                     string                `json:"branches,omitempty"`


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->
 
<!-- You can skip this if you're fixing a typo. -->
# Checklist
- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated.
- [ ] Changelog entry has been written

The API has supported exposing the publicKey on its own field rather than requiring users to decode the privateKey. This updates the CLI to use this new field where possible, and only request the privateKey if reveal is requested (to respect permissions in the api)

# Changelog Entry
<!--
Describe the change in order to make it visible in the changelog
If the change breaks anything document this - how was the functionality before - how does it work after the change

Prefix the change with: Feature, Change, Bugfix, Improvement, Documentation

Use following format:
Improvement - Description (#ISSUENUMBER)
-->
