### PR TITLE
Change: Moves `AddOrganizationCmd` from a subcommand to the top level for Organization

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -35,13 +35,6 @@ var addOrganizationCmd = &cobra.Command{
 		validateToken(lagoonCLIConfig.Current) // get a new token if the current one is invalid
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		//fmt.Println(args)
-		//var commandNames []string
-		//for _, command := range cmd.Commands() {
-		//	commandNames = append(commandNames, append(command.Aliases, command.Name())...)
-		//}
-		//fmt.Println(commandNames)
-		//return nil
 		debug, err := cmd.Flags().GetBool("debug")
 		if err != nil {
 			return err

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -1,7 +1,12 @@
 package cmd
 
 import (
+	"context"
+
 	"github.com/spf13/cobra"
+	"github.com/uselagoon/lagoon-cli/pkg/output"
+	lclient "github.com/uselagoon/machinery/api/lagoon/client"
+	s "github.com/uselagoon/machinery/api/schema"
 )
 
 var addCmd = &cobra.Command{
@@ -25,9 +30,88 @@ var addNotificationCmd = &cobra.Command{
 var addOrganizationCmd = &cobra.Command{
 	Use:     "organization",
 	Aliases: []string{"o"},
-	Short:   "Add an organization, or add a group/project to an organization",
+	Short:   "Add an organization, or add a deploytarget/group/project/user to an organization",
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		validateToken(lagoonCLIConfig.Current) // get a new token if the current one is invalid
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		//fmt.Println(args)
+		//var commandNames []string
+		//for _, command := range cmd.Commands() {
+		//	commandNames = append(commandNames, append(command.Aliases, command.Name())...)
+		//}
+		//fmt.Println(commandNames)
+		//return nil
+		debug, err := cmd.Flags().GetBool("debug")
+		if err != nil {
+			return err
+		}
+		organizationName, err := cmd.Flags().GetString("name")
+		if err != nil {
+			return err
+		}
+		if err := requiredInputCheck("Organization name", organizationName); err != nil {
+			return err
+		}
+		organizationFriendlyName, err := cmd.Flags().GetString("friendly-name")
+		if err != nil {
+			return err
+		}
+		organizationDescription, err := cmd.Flags().GetString("description")
+		if err != nil {
+			return err
+		}
+		organizationQuotaProject, err := cmd.Flags().GetInt("project-quota")
+		if err != nil {
+			return err
+		}
+		organizationQuotaGroup, err := cmd.Flags().GetInt("group-quota")
+		if err != nil {
+			return err
+		}
+		organizationQuotaNotification, err := cmd.Flags().GetInt("notification-quota")
+		if err != nil {
+			return err
+		}
+		organizationQuotaEnvironment, err := cmd.Flags().GetInt("environment-quota")
+		if err != nil {
+			return err
+		}
+		organizationQuotaRoute, err := cmd.Flags().GetInt("route-quota")
+		if err != nil {
+			return err
+		}
+
+		current := lagoonCLIConfig.Current
+		token := lagoonCLIConfig.Lagoons[current].Token
+		lc := lclient.New(
+			lagoonCLIConfig.Lagoons[current].GraphQL,
+			lagoonCLIVersion,
+			&token,
+			debug)
+
+		organizationInput := s.AddOrganizationInput{
+			Name:              organizationName,
+			FriendlyName:      organizationFriendlyName,
+			Description:       organizationDescription,
+			QuotaProject:      organizationQuotaProject,
+			QuotaGroup:        organizationQuotaGroup,
+			QuotaNotification: organizationQuotaNotification,
+			QuotaEnvironment:  organizationQuotaEnvironment,
+			QuotaRoute:        organizationQuotaRoute,
+		}
+		org := s.Organization{}
+		err = lc.AddOrganization(context.TODO(), &organizationInput, &org)
+		handleError(err)
+
+		resultData := output.Result{
+			Result: "success",
+			ResultData: map[string]interface{}{
+				"Organization Name": organizationName,
+			},
+		}
+		output.RenderResult(resultData, outputOptions)
+		return nil
 	},
 }
 
@@ -43,4 +127,13 @@ func init() {
 	addCmd.AddCommand(addUserSSHKeyCmd)
 	addCmd.AddCommand(addVariableCmd)
 	addCmd.AddCommand(addDeployTargetConfigCmd)
+
+	addOrganizationCmd.Flags().StringP("name", "O", "", "Name of the organization")
+	addOrganizationCmd.Flags().String("friendly-name", "", "Friendly name of the organization")
+	addOrganizationCmd.Flags().String("description", "", "Description of the organization")
+	addOrganizationCmd.Flags().Int("project-quota", 0, "Project quota for the organization")
+	addOrganizationCmd.Flags().Int("group-quota", 0, "Group quota for the organization")
+	addOrganizationCmd.Flags().Int("notification-quota", 0, "Notification quota for the organization")
+	addOrganizationCmd.Flags().Int("environment-quota", 0, "Environment quota for the organization")
+	addOrganizationCmd.Flags().Int("route-quota", 0, "Route quota for the organization")
 }

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/spf13/cobra"
 	"github.com/uselagoon/lagoon-cli/pkg/output"
@@ -44,7 +45,7 @@ var addOrganizationCmd = &cobra.Command{
 			return err
 		}
 		if err := requiredInputCheck("Organization name", organizationName); err != nil {
-			return err
+			return fmt.Errorf("%v | Additional subcommands for deploytarget, group, project & user are available. --help for more information", err)
 		}
 		organizationFriendlyName, err := cmd.Flags().GetString("friendly-name")
 		if err != nil {

--- a/cmd/organization.go
+++ b/cmd/organization.go
@@ -10,87 +10,6 @@ import (
 	s "github.com/uselagoon/machinery/api/schema"
 )
 
-var addOrgCmd = &cobra.Command{
-	Use:     "organization",
-	Aliases: []string{"o"},
-	Short:   "Add a new organization to Lagoon",
-	PreRunE: func(_ *cobra.Command, _ []string) error {
-		return validateTokenE(lagoonCLIConfig.Current)
-	},
-	RunE: func(cmd *cobra.Command, args []string) error {
-		debug, err := cmd.Flags().GetBool("debug")
-		if err != nil {
-			return err
-		}
-		organizationName, err := cmd.Flags().GetString("name")
-		if err != nil {
-			return err
-		}
-		if err := requiredInputCheck("Organization name", organizationName); err != nil {
-			return err
-		}
-		organizationFriendlyName, err := cmd.Flags().GetString("friendly-name")
-		if err != nil {
-			return err
-		}
-		organizationDescription, err := cmd.Flags().GetString("description")
-		if err != nil {
-			return err
-		}
-		organizationQuotaProject, err := cmd.Flags().GetInt("project-quota")
-		if err != nil {
-			return err
-		}
-		organizationQuotaGroup, err := cmd.Flags().GetInt("group-quota")
-		if err != nil {
-			return err
-		}
-		organizationQuotaNotification, err := cmd.Flags().GetInt("notification-quota")
-		if err != nil {
-			return err
-		}
-		organizationQuotaEnvironment, err := cmd.Flags().GetInt("environment-quota")
-		if err != nil {
-			return err
-		}
-		organizationQuotaRoute, err := cmd.Flags().GetInt("route-quota")
-		if err != nil {
-			return err
-		}
-
-		current := lagoonCLIConfig.Current
-		token := lagoonCLIConfig.Lagoons[current].Token
-		lc := lclient.New(
-			lagoonCLIConfig.Lagoons[current].GraphQL,
-			lagoonCLIVersion,
-			&token,
-			debug)
-
-		organizationInput := s.AddOrganizationInput{
-			Name:              organizationName,
-			FriendlyName:      organizationFriendlyName,
-			Description:       organizationDescription,
-			QuotaProject:      organizationQuotaProject,
-			QuotaGroup:        organizationQuotaGroup,
-			QuotaNotification: organizationQuotaNotification,
-			QuotaEnvironment:  organizationQuotaEnvironment,
-			QuotaRoute:        organizationQuotaRoute,
-		}
-		org := s.Organization{}
-		err = lc.AddOrganization(context.TODO(), &organizationInput, &org)
-		handleError(err)
-
-		resultData := output.Result{
-			Result: "success",
-			ResultData: map[string]interface{}{
-				"Organization Name": organizationName,
-			},
-		}
-		output.RenderResult(resultData, outputOptions)
-		return nil
-	},
-}
-
 var deleteOrgCmd = &cobra.Command{
 	Use:     "organization",
 	Aliases: []string{"o"},
@@ -217,7 +136,6 @@ var updateOrganizationCmd = &cobra.Command{
 }
 
 func init() {
-	addOrganizationCmd.AddCommand(addOrgCmd)
 	addOrganizationCmd.AddCommand(addGroupToOrganizationCmd)
 	addOrganizationCmd.AddCommand(addProjectToOrganizationCmd)
 	addOrganizationCmd.AddCommand(addDeployTargetToOrganizationCmd)
@@ -227,15 +145,6 @@ func init() {
 	deleteOrganizationCmd.AddCommand(RemoveDeployTargetFromOrganizationCmd)
 	deleteOrganizationCmd.AddCommand(RemoveProjectFromOrganizationCmd)
 	deleteOrganizationCmd.AddCommand(RemoveUserFromOrganization)
-
-	addOrgCmd.Flags().StringP("name", "O", "", "Name of the organization")
-	addOrgCmd.Flags().String("friendly-name", "", "Friendly name of the organization")
-	addOrgCmd.Flags().String("description", "", "Description of the organization")
-	addOrgCmd.Flags().Int("project-quota", 0, "Project quota for the organization")
-	addOrgCmd.Flags().Int("group-quota", 0, "Group quota for the organization")
-	addOrgCmd.Flags().Int("notification-quota", 0, "Notification quota for the organization")
-	addOrgCmd.Flags().Int("environment-quota", 0, "Environment quota for the organization")
-	addOrgCmd.Flags().Int("route-quota", 0, "Route quota for the organization")
 
 	updateOrganizationCmd.Flags().StringP("name", "O", "", "Name of the organization to update")
 	updateOrganizationCmd.Flags().String("friendly-name", "", "Friendly name of the organization")

--- a/docs/commands/lagoon_add.md
+++ b/docs/commands/lagoon_add.md
@@ -32,7 +32,7 @@ Add a project, or add notifications and variables to projects or environments
 * [lagoon add deploytarget-config](lagoon_add_deploytarget-config.md)	 - Add deploytarget config to a project
 * [lagoon add group](lagoon_add_group.md)	 - Add a group to lagoon
 * [lagoon add notification](lagoon_add_notification.md)	 - Add notifications or add notifications to projects
-* [lagoon add organization](lagoon_add_organization.md)	 - Add an organization, or add a group/project to an organization
+* [lagoon add organization](lagoon_add_organization.md)	 - Add an organization, or add a deploytarget/group/project/user to an organization
 * [lagoon add project](lagoon_add_project.md)	 - Add a new project to Lagoon
 * [lagoon add project-group](lagoon_add_project-group.md)	 - Add a project to a group in lagoon
 * [lagoon add user](lagoon_add_user.md)	 - Add a user to lagoon

--- a/docs/commands/lagoon_add_organization.md
+++ b/docs/commands/lagoon_add_organization.md
@@ -1,11 +1,23 @@
 ## lagoon add organization
 
-Add an organization, or add a group/project to an organization
+Add an organization, or add a deploytarget/group/project/user to an organization
+
+```
+lagoon add organization [flags]
+```
 
 ### Options
 
 ```
-  -h, --help   help for organization
+      --description string       Description of the organization
+      --environment-quota int    Environment quota for the organization
+      --friendly-name string     Friendly name of the organization
+      --group-quota int          Group quota for the organization
+  -h, --help                     help for organization
+  -O, --name string              Name of the organization
+      --notification-quota int   Notification quota for the organization
+      --project-quota int        Project quota for the organization
+      --route-quota int          Route quota for the organization
 ```
 
 ### Options inherited from parent commands
@@ -30,7 +42,6 @@ Add an organization, or add a group/project to an organization
 * [lagoon add](lagoon_add.md)	 - Add a project, or add notifications and variables to projects or environments
 * [lagoon add organization deploytarget](lagoon_add_organization_deploytarget.md)	 - Add a deploy target to an Organization
 * [lagoon add organization group](lagoon_add_organization_group.md)	 - Add a group to an Organization
-* [lagoon add organization organization](lagoon_add_organization_organization.md)	 - Add a new organization to Lagoon
 * [lagoon add organization project](lagoon_add_organization_project.md)	 - Add a project to an Organization
 * [lagoon add organization user](lagoon_add_organization_user.md)	 - Add a user to an Organization
 

--- a/docs/commands/lagoon_add_organization_deploytarget.md
+++ b/docs/commands/lagoon_add_organization_deploytarget.md
@@ -33,5 +33,5 @@ lagoon add organization deploytarget [flags]
 
 ### SEE ALSO
 
-* [lagoon add organization](lagoon_add_organization.md)	 - Add an organization, or add a group/project to an organization
+* [lagoon add organization](lagoon_add_organization.md)	 - Add an organization, or add a deploytarget/group/project/user to an organization
 

--- a/docs/commands/lagoon_add_organization_group.md
+++ b/docs/commands/lagoon_add_organization_group.md
@@ -34,5 +34,5 @@ lagoon add organization group [flags]
 
 ### SEE ALSO
 
-* [lagoon add organization](lagoon_add_organization.md)	 - Add an organization, or add a group/project to an organization
+* [lagoon add organization](lagoon_add_organization.md)	 - Add an organization, or add a deploytarget/group/project/user to an organization
 

--- a/docs/commands/lagoon_add_organization_project.md
+++ b/docs/commands/lagoon_add_organization_project.md
@@ -53,5 +53,5 @@ lagoon add organization project [flags]
 
 ### SEE ALSO
 
-* [lagoon add organization](lagoon_add_organization.md)	 - Add an organization, or add a group/project to an organization
+* [lagoon add organization](lagoon_add_organization.md)	 - Add an organization, or add a deploytarget/group/project/user to an organization
 

--- a/docs/commands/lagoon_add_organization_user.md
+++ b/docs/commands/lagoon_add_organization_user.md
@@ -34,5 +34,5 @@ lagoon add organization user [flags]
 
 ### SEE ALSO
 
-* [lagoon add organization](lagoon_add_organization.md)	 - Add an organization, or add a group/project to an organization
+* [lagoon add organization](lagoon_add_organization.md)	 - Add an organization, or add a deploytarget/group/project/user to an organization
 


### PR DESCRIPTION
# Checklist
- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated.
- [ ] Changelog entry has been written

Moves the `addOrg` command from a subcommand to the top level for `Organizations`. This changes the command structure for adding a new `Organization` from `lagoon add organization organization --name` to `lagoon add organization --name`.

Also updates the error when no flag is provided for `lagoon add organization` - highlighting the available subcommands.
