### PR TITLE
feat: add raw query command functionality

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,8 +39,8 @@ build-linux: test
 build-darwin: test
 	GO111MODULE=on CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 $(GOCMD) build -ldflags '${LDFLAGS} -X "${PKG}/cmd.lagoonCLIBuildGoVersion=${GO_VER}"' -o builds/lagoon-cli-${VERSION}-darwin-amd64 -v
 
-docs: test build
-	GO111MODULE=on $(GOCMD) run main.go --docs
+docs: test
+	LAGOON_GEN_DOCS=true GO111MODULE=on $(GOCMD) run main.go --docs 
 
 tidy:
 	GO111MODULE=on $(GOCMD) mod tidy

--- a/cmd/raw.go
+++ b/cmd/raw.go
@@ -1,0 +1,58 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	lclient "github.com/uselagoon/machinery/api/lagoon/client"
+)
+
+var rawCmd = &cobra.Command{
+	Use:     "raw",
+	Aliases: []string{"r"},
+	Short:   "Run a custom query or mutation",
+	Long: `Run a custom query or mutation.
+The output of this command will be the JSON response from the API`,
+	PreRunE: func(_ *cobra.Command, _ []string) error {
+		return validateTokenE(cmdLagoon)
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		debug, err := cmd.Flags().GetBool("debug")
+		if err != nil {
+			return err
+		}
+		raw, err := cmd.Flags().GetString("raw")
+		if err != nil {
+			return err
+		}
+		if err := requiredInputCheck("Raw query or mutation", raw); err != nil {
+			return err
+		}
+		current := lagoonCLIConfig.Current
+		token := lagoonCLIConfig.Lagoons[current].Token
+		lc := lclient.New(
+			lagoonCLIConfig.Lagoons[current].GraphQL,
+			lagoonCLIVersion,
+			&token,
+			debug)
+		if err != nil {
+			return err
+		}
+		rawResp, err := lc.ProcessRaw(context.TODO(), raw, nil)
+		if err != nil {
+			return err
+		}
+		r, err := json.Marshal(rawResp)
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(r))
+		return nil
+	},
+}
+
+func init() {
+	rawCmd.Flags().String("raw", "", "The raw query or mutation to run")
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -38,6 +38,7 @@ var configExtension = ".yml"
 var createConfig bool
 var userPath string
 var configFilePath string
+var commandsFilePath = ".lagoon-cli/commands"
 var updateDocURL = "https://uselagoon.github.io/lagoon-cli"
 
 var skipUpdateCheck bool
@@ -195,6 +196,7 @@ Use "{{.CommandPath}} [command] --help" for more information about a command.{{e
 	rootCmd.AddCommand(exportCmd)
 	rootCmd.AddCommand(whoamiCmd)
 	rootCmd.AddCommand(uploadCmd)
+	rootCmd.AddCommand(rawCmd)
 }
 
 // version/build information command

--- a/docs/commands/lagoon.md
+++ b/docs/commands/lagoon.md
@@ -42,6 +42,7 @@ lagoon [flags]
 * [lagoon kibana](lagoon_kibana.md)	 - Launch the kibana interface
 * [lagoon list](lagoon_list.md)	 - List projects, environments, deployments, variables or notifications
 * [lagoon login](lagoon_login.md)	 - Log into a Lagoon instance
+* [lagoon raw](lagoon_raw.md)	 - Run a custom query or mutation
 * [lagoon retrieve](lagoon_retrieve.md)	 - Trigger a retrieval operation on backups
 * [lagoon run](lagoon_run.md)	 - Run a task against an environment
 * [lagoon ssh](lagoon_ssh.md)	 - Display the SSH command to access a specific environment in a project

--- a/docs/commands/lagoon_raw.md
+++ b/docs/commands/lagoon_raw.md
@@ -1,0 +1,41 @@
+## lagoon raw
+
+Run a custom query or mutation
+
+### Synopsis
+
+Run a custom query or mutation.
+The output of this command will be the JSON response from the API
+
+```
+lagoon raw [flags]
+```
+
+### Options
+
+```
+  -h, --help         help for raw
+      --raw string   The raw query or mutation to run
+```
+
+### Options inherited from parent commands
+
+```
+      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
+      --debug                Enable debugging output (if supported)
+  -e, --environment string   Specify an environment to use
+      --force                Force yes on prompts (if supported)
+  -l, --lagoon string        The Lagoon instance to interact with
+      --no-header            No header on table (if supported)
+      --output-csv           Output as CSV (if supported)
+      --output-json          Output as JSON (if supported)
+      --pretty               Make JSON pretty (if supported)
+  -p, --project string       Specify a project to use
+      --skip-update-check    Skip checking for updates
+  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+```
+
+### SEE ALSO
+
+* [lagoon](lagoon.md)	 - Command line integration for Lagoon
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,3 +47,4 @@ nav:
   - Getting Started: index.md
   - Configuration: config.md
   - Commands: commands/lagoon.md
+  - Custom Commands: customcommands.md


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->
 
<!-- You can skip this if you're fixing a typo. -->
# Checklist
- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated.
- [ ] Changelog entry has been written

This adds support for the `raw` command which allows users to pass raw graphql commands to the API. The output is raw JSON like the API would respond with, this way tools like `jq` can be used on the output.

Example to list all projects.
```
lagoon raw --raw 'query allProjects{ allProjects { name } }' | jq
```

# Changelog Entry
<!--
Describe the change in order to make it visible in the changelog
If the change breaks anything document this - how was the functionality before - how does it work after the change

Prefix the change with: Feature, Change, Bugfix, Improvement, Documentation

Use following format:
Improvement - Description (#ISSUENUMBER)
-->
