### PR TITLE
fix: use stringarray instead of stringslice for buildvars

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+
 	"github.com/spf13/cobra"
 	"github.com/uselagoon/lagoon-cli/internal/lagoon"
 	"github.com/uselagoon/lagoon-cli/internal/lagoon/client"
@@ -46,7 +47,7 @@ use 'lagoon deploy latest' instead`,
 			return fmt.Errorf("Missing arguments: Project name or branch name is not defined")
 		}
 
-		buildVarStrings, err := cmd.Flags().GetStringSlice("buildvar")
+		buildVarStrings, err := cmd.Flags().GetStringArray("buildvar")
 		if err != nil {
 			return err
 		}
@@ -111,7 +112,7 @@ var deployPromoteCmd = &cobra.Command{
 			return fmt.Errorf("Missing arguments: Project name, source environment, or destination environment is not defined")
 		}
 
-		buildVarStrings, err := cmd.Flags().GetStringSlice("buildvar")
+		buildVarStrings, err := cmd.Flags().GetStringArray("buildvar")
 		if err != nil {
 			return err
 		}
@@ -165,7 +166,7 @@ This environment should already exist in lagoon. It is analogous with the 'Deplo
 			return err
 		}
 
-		buildVarStrings, err := cmd.Flags().GetStringSlice("buildvar")
+		buildVarStrings, err := cmd.Flags().GetStringArray("buildvar")
 		if err != nil {
 			return err
 		}
@@ -247,7 +248,7 @@ This pullrequest may not already exist as an environment in lagoon.`,
 			baseBranchRef == "" || headBranchName == "" || headBranchRef == "" {
 			return fmt.Errorf("Missing arguments: Project name, title, number, baseBranchName, baseBranchRef, headBranchName, or headBranchRef is not defined")
 		}
-		buildVarStrings, err := cmd.Flags().GetStringSlice("buildvar")
+		buildVarStrings, err := cmd.Flags().GetStringArray("buildvar")
 		if err != nil {
 			return err
 		}
@@ -304,17 +305,17 @@ func init() {
 
 	const returnDataUsageText = "Returns the build name instead of success text"
 	deployLatestCmd.Flags().Bool("returnData", false, returnDataUsageText)
-	deployLatestCmd.Flags().StringSlice("buildvar", []string{}, "Add one or more build variables to deployment (--buildvar KEY1=VALUE1 [--buildvar KEY2=VALUE2])")
+	deployLatestCmd.Flags().StringArray("buildvar", []string{}, "Add one or more build variables to deployment (--buildvar KEY1=VALUE1 [--buildvar KEY2=VALUE2])")
 
 	deployBranchCmd.Flags().StringP("branch", "b", "", "Branch name to deploy")
 	deployBranchCmd.Flags().StringP("branchRef", "r", "", "Branch ref to deploy")
 	deployBranchCmd.Flags().Bool("returnData", false, returnDataUsageText)
-	deployBranchCmd.Flags().StringSlice("buildvar", []string{}, "Add one or more build variables to deployment (--buildvar KEY1=VALUE1 [--buildvar KEY2=VALUE2])")
+	deployBranchCmd.Flags().StringArray("buildvar", []string{}, "Add one or more build variables to deployment (--buildvar KEY1=VALUE1 [--buildvar KEY2=VALUE2])")
 
 	deployPromoteCmd.Flags().StringP("destination", "d", "", "Destination environment name to create")
 	deployPromoteCmd.Flags().StringP("source", "s", "", "Source environment name to use as the base to deploy from")
 	deployPromoteCmd.Flags().Bool("returnData", false, returnDataUsageText)
-	deployPromoteCmd.Flags().StringSlice("buildvar", []string{}, "Add one or more build variables to deployment (--buildvar KEY1=VALUE1 [--buildvar KEY2=VALUE2])")
+	deployPromoteCmd.Flags().StringArray("buildvar", []string{}, "Add one or more build variables to deployment (--buildvar KEY1=VALUE1 [--buildvar KEY2=VALUE2])")
 
 	deployPullrequestCmd.Flags().StringP("title", "t", "", "Pullrequest title")
 	deployPullrequestCmd.Flags().UintP("number", "n", 0, "Pullrequest number")
@@ -323,5 +324,5 @@ func init() {
 	deployPullrequestCmd.Flags().StringP("headBranchName", "H", "", "Pullrequest head branch name")
 	deployPullrequestCmd.Flags().StringP("headBranchRef", "M", "", "Pullrequest head branch reference hash")
 	deployPullrequestCmd.Flags().Bool("returnData", false, returnDataUsageText)
-	deployPullrequestCmd.Flags().StringSlice("buildvar", []string{}, "Add one or more build variables to deployment (--buildvar KEY1=VALUE1 [--buildvar KEY2=VALUE2])")
+	deployPullrequestCmd.Flags().StringArray("buildvar", []string{}, "Add one or more build variables to deployment (--buildvar KEY1=VALUE1 [--buildvar KEY2=VALUE2])")
 }

--- a/cmd/helpers_test.go
+++ b/cmd/helpers_test.go
@@ -1,9 +1,10 @@
 package cmd
 
 import (
-	"github.com/uselagoon/lagoon-cli/internal/schema"
 	"reflect"
 	"testing"
+
+	"github.com/uselagoon/lagoon-cli/internal/schema"
 
 	"github.com/guregu/null"
 	"github.com/spf13/pflag"
@@ -240,6 +241,21 @@ func Test_buildVarsToMap(t *testing.T) {
 				{
 					Name:  "KEY1",
 					Value: "VAL1==",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Valid case - entry with comma separated items",
+			args: args{
+				slice: []string{
+					`KEY1=type:thistype,othertype:thisone`,
+				},
+			},
+			want: []schema.EnvKeyValueInput{
+				{
+					Name:  "KEY1",
+					Value: "type:thistype,othertype:thisone",
 				},
 			},
 			wantErr: false,


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->
 
<!-- You can skip this if you're fixing a typo. -->
# Checklist
- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated.
- [ ] Changelog entry has been written

The `StringSlice` type has some checks that splits with comma separated values, `StringArray` doesn't appear to do the same thing. This updates the commands to use the `StringArray` type.

# Changelog Entry
<!--
Describe the change in order to make it visible in the changelog
If the change breaks anything document this - how was the functionality before - how does it work after the change

Prefix the change with: Feature, Change, Bugfix, Improvement, Documentation

Use following format:
Improvement - Description (#ISSUENUMBER)
-->

# Closing issues
closes #333 