### PR TITLE
fix: pass role through to api directly to better capture misspelled roles

### DIFF
--- a/cmd/shared.go
+++ b/cmd/shared.go
@@ -2,9 +2,10 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/uselagoon/lagoon-cli/pkg/output"
 	"os"
 	"strings"
+
+	"github.com/uselagoon/lagoon-cli/pkg/output"
 )
 
 // config vars
@@ -36,7 +37,6 @@ var osToken string
 
 // group vars
 var groupName string
-var groupRole string
 
 var jsonPatch string
 var revealValue bool


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->
 
<!-- You can skip this if you're fixing a typo. -->
# Checklist
- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated.
- [ ] Changelog entry has been written

Fixes the error where a mistyped role name would result in the user being added as a guest (fallback). It will now check if the `--role` flag is provided, and if so provides the value of this to the mutation, which if the user has typed incorrectly will result in a graphql error. The guest fallback remains for times where the `--role` flag is omitted.

# Closing issues
closes #336 
