### PR TITLE
refactor: refactor and fix organizationbyname to error if organization not found

### DIFF
--- a/cmd/deploytarget.go
+++ b/cmd/deploytarget.go
@@ -361,6 +361,9 @@ var addDeployTargetToOrganizationCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		if organization.Name == "" {
+			return fmt.Errorf("error querying organization by name")
+		}
 
 		deployTargetInput := s.AddDeployTargetToOrganizationInput{
 			DeployTarget: deploytarget,
@@ -420,6 +423,9 @@ var removeDeployTargetFromOrganizationCmd = &cobra.Command{
 		organization, err := l.GetOrganizationByName(context.TODO(), organizationName, lc)
 		if err != nil {
 			return err
+		}
+		if organization.Name == "" {
+			return fmt.Errorf("error querying organization by name")
 		}
 
 		deployTargetInput := s.RemoveDeployTargetFromOrganizationInput{

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -288,10 +288,8 @@ var getOrganizationCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-
 		if organization.Name == "" {
-			output.RenderInfo(fmt.Sprintf("No organization found for '%s'", organizationName), outputOptions)
-			return nil
+			return fmt.Errorf("error querying organization by name")
 		}
 
 		data := []output.Data{}

--- a/cmd/groups.go
+++ b/cmd/groups.go
@@ -73,6 +73,9 @@ var addGroupCmd = &cobra.Command{
 			if err != nil {
 				return err
 			}
+			if organization.Name == "" {
+				return fmt.Errorf("error querying organization by name")
+			}
 			groupInput := s.AddGroupToOrganizationInput{
 				Name:         groupName,
 				Organization: organization.ID,

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -657,11 +657,14 @@ var listOrganizationProjectsCmd = &cobra.Command{
 			&token,
 			debug)
 
-		org, err := l.GetOrganizationByName(context.TODO(), organizationName, lc)
+		organization, err := l.GetOrganizationByName(context.TODO(), organizationName, lc)
 		if err != nil {
 			return err
 		}
-		orgProjects, err := l.ListProjectsByOrganizationID(context.TODO(), org.ID, lc)
+		if organization.Name == "" {
+			return fmt.Errorf("error querying organization by name")
+		}
+		orgProjects, err := l.ListProjectsByOrganizationID(context.TODO(), organization.ID, lc)
 		if err != nil {
 			return err
 		}
@@ -716,11 +719,14 @@ var listOrganizationGroupsCmd = &cobra.Command{
 			&token,
 			debug)
 
-		org, err := l.GetOrganizationByName(context.TODO(), organizationName, lc)
+		organization, err := l.GetOrganizationByName(context.TODO(), organizationName, lc)
 		if err != nil {
 			return err
 		}
-		orgGroups, err := l.ListGroupsByOrganizationID(context.TODO(), org.ID, lc)
+		if organization.Name == "" {
+			return fmt.Errorf("error querying organization by name")
+		}
+		orgGroups, err := l.ListGroupsByOrganizationID(context.TODO(), organization.ID, lc)
 		if err != nil {
 			return err
 		}
@@ -838,6 +844,9 @@ var ListOrganizationUsersCmd = &cobra.Command{
 		organization, err := l.GetOrganizationByName(context.Background(), organizationName, lc)
 		if err != nil {
 			return err
+		}
+		if organization.Name == "" {
+			return fmt.Errorf("error querying organization by name")
 		}
 		users, err := l.UsersByOrganization(context.TODO(), organization.ID, lc)
 		if err != nil {

--- a/cmd/organization.go
+++ b/cmd/organization.go
@@ -128,6 +128,9 @@ var deleteOrganizationCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		if organization.Name == "" {
+			return fmt.Errorf("error querying organization by name")
+		}
 		if yesNo(fmt.Sprintf("You are attempting to delete organization '%s', are you sure?", organization.Name)) {
 			_, err := l.DeleteOrganization(context.TODO(), organization.ID, lc)
 			if err != nil {
@@ -159,9 +162,6 @@ var updateOrganizationCmd = &cobra.Command{
 			return err
 		}
 		if err := requiredInputCheck("Organization name", organizationName); err != nil {
-			return err
-		}
-		if err != nil {
 			return err
 		}
 		organizationFriendlyName, err := cmd.Flags().GetString("friendly-name")
@@ -205,6 +205,9 @@ var updateOrganizationCmd = &cobra.Command{
 		organization, err := l.GetOrganizationByName(context.TODO(), organizationName, lc)
 		if err != nil {
 			return err
+		}
+		if organization.Name == "" {
+			return fmt.Errorf("error querying organization by name")
 		}
 		organizationInput := s.UpdateOrganizationPatchInput{
 			Description:       nullStrCheck(organizationDescription),

--- a/cmd/users.go
+++ b/cmd/users.go
@@ -409,6 +409,9 @@ var addAdministratorToOrganizationCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		if organization.Name == "" {
+			return fmt.Errorf("error querying organization by name")
+		}
 
 		userInput := s.AddUserToOrganizationInput{
 			User:         s.UserInput{Email: userEmail},
@@ -478,6 +481,9 @@ var removeAdministratorFromOrganizationCmd = &cobra.Command{
 		organization, err := l.GetOrganizationByName(context.TODO(), organizationName, lc)
 		if err != nil {
 			return err
+		}
+		if organization.Name == "" {
+			return fmt.Errorf("error querying organization by name")
 		}
 
 		userInput := s.AddUserToOrganizationInput{

--- a/docs/commands/lagoon_add_project.md
+++ b/docs/commands/lagoon_add_project.md
@@ -22,6 +22,7 @@ lagoon add project [flags]
   -j, --json string                           JSON string to patch
   -S, --openshift uint                        Reference to OpenShift Object this Project should be deployed to
   -o, --openshiftProjectPattern string        Pattern of OpenShift Project/Namespace that should be generated
+      --organization-id uint                  ID of the Organization to add the project to
   -O, --organization-name string              Name of the Organization to add the project to
       --owner                                 Add the user as an owner of the project
   -I, --privateKey string                     Private key to use for the project


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

Just refactors commands using `GetOrganizationByName` to check if the returned organization contains something, [since the API will return null](https://github.com/uselagoon/lagoon/blob/v2.19.0/services/api/src/resources/organization/resolvers.ts#L264) instead of an error

Also added an `organization-id` flag to the `add project` command to be able to shortcut `GetOrganizationByName` if the ID is known.