### PR TITLE
feat: support for identityfiles to select keys from ssh-agent

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -164,6 +164,14 @@ var configAddCmd = &cobra.Command{
 			if lagoonConfig.SSHKey != "" {
 				lc.SSHKey = lagoonConfig.SSHKey
 			}
+			// check identity files flag
+			identityFiles, err := cmd.Flags().GetStringSlice("publickey-identityfile")
+			if err != nil {
+				return err
+			}
+			if identityFiles != nil {
+				lc.PublicKeyIdentities = identityFiles
+			}
 			lagoonCLIConfig.Lagoons[lagoonConfig.Lagoon] = lc
 			if err := writeLagoonConfig(&lagoonCLIConfig, filepath.Join(configFilePath, configName+configExtension)); err != nil {
 				return fmt.Errorf("couldn't write config: %v", err)
@@ -314,6 +322,8 @@ func init() {
 		"Lagoon Kibana URL (https://logs.amazeeio.cloud)")
 	configAddCmd.Flags().StringVarP(&lagoonSSHKey, "ssh-key", "", "",
 		"SSH Key to use for this cluster for generating tokens")
+	configAddCmd.Flags().StringSliceP("publickey-identityfile", "", []string{},
+		"Specific public key identity files to use when doing ssh-agent checks (support multiple)")
 	configLagoonsCmd.Flags().BoolVarP(&fullConfigList, "show-full", "", false,
 		"Show full config output when listing Lagoon configurations")
 	configFeatureSwitch.Flags().StringVarP(&updateCheck, "disable-update-check", "", "",

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -112,7 +112,7 @@ func getSSHClientConfig(environmentName string) (*ssh.ClientConfig,
 		return nil, nil, fmt.Errorf("couldn't get ~/.ssh/known_hosts: %v", err)
 	}
 	// configure an SSH client session
-	authMethod, closeSSHAgent := publicKey(privateKey, skipAgent)
+	authMethod, closeSSHAgent := publicKey(privateKey, cmdPubkeyIdentity, lagoonCLIConfig.Lagoons[lagoonCLIConfig.Current].PublicKeyIdentities, skipAgent)
 	return &ssh.ClientConfig{
 		User:            cmdProjectName + "-" + environmentName,
 		Auth:            []ssh.AuthMethod{authMethod},

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,6 +26,7 @@ var cmdProject app.LagoonProject
 var cmdLagoon = ""
 var forceAction bool
 var cmdSSHKey = ""
+var cmdPubkeyIdentity = ""
 var inputScanner = bufio.NewScanner(os.Stdin)
 var versionFlag bool
 var docsFlag bool
@@ -36,6 +37,7 @@ var createConfig bool
 var userPath string
 var configFilePath string
 var updateDocURL = "https://uselagoon.github.io/lagoon-cli"
+var verboseOutput bool
 
 var skipUpdateCheck bool
 
@@ -129,6 +131,8 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&cmdLagoon, "lagoon", "l", "", "The Lagoon instance to interact with")
 	rootCmd.PersistentFlags().BoolVarP(&forceAction, "force", "", false, "Force yes on prompts (if supported)")
 	rootCmd.PersistentFlags().StringVarP(&cmdSSHKey, "ssh-key", "i", "", "Specify path to a specific SSH key to use for lagoon authentication")
+	rootCmd.PersistentFlags().StringVarP(&cmdPubkeyIdentity, "ssh-publickey", "", "",
+		"Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.\nThis will override any public key identities defined in configuration")
 
 	// rootCmd.PersistentFlags().BoolVarP(&listAllProjects, "all-projects", "", false, "All projects (if supported)")
 	rootCmd.PersistentFlags().BoolVarP(&outputOptions.Header, "no-header", "", false, "No header on table (if supported)")
@@ -137,6 +141,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVarP(&outputOptions.Pretty, "pretty", "", false, "Make JSON pretty (if supported)")
 	rootCmd.PersistentFlags().BoolVarP(&debugEnable, "debug", "", false, "Enable debugging output (if supported)")
 	rootCmd.PersistentFlags().BoolVarP(&skipUpdateCheck, "skip-update-check", "", false, "Skip checking for updates")
+	rootCmd.PersistentFlags().BoolVarP(&verboseOutput, "verbose", "v", false, "Enable verbose output to stderr (if supported)")
 
 	// get config-file from flag
 	rootCmd.PersistentFlags().StringP("config-file", "", "", "Path to the config file to use (must be *.yml or *.yaml)")

--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -95,7 +95,7 @@ var sshEnvCmd = &cobra.Command{
 		} else {
 
 			// start an interactive ssh session
-			authMethod, closeSSHAgent := publicKey(privateKey, skipAgent)
+			authMethod, closeSSHAgent := publicKey(privateKey, cmdPubkeyIdentity, lagoonCLIConfig.Lagoons[lagoonCLIConfig.Current].PublicKeyIdentities, skipAgent)
 			config := &ssh.ClientConfig{
 				User: sshConfig["username"],
 				Auth: []ssh.AuthMethod{

--- a/docs/commands/lagoon.md
+++ b/docs/commands/lagoon.md
@@ -13,20 +13,23 @@ lagoon [flags]
 ### Options
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -h, --help                 help for lagoon
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
-      --version              Version information
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -h, --help                   help for lagoon
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
+      --version                Version information
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_add.md
+++ b/docs/commands/lagoon_add.md
@@ -11,18 +11,21 @@ Add a project, or add notifications and variables to projects or environments
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_add_deploytarget-config.md
+++ b/docs/commands/lagoon_add_deploytarget-config.md
@@ -19,18 +19,21 @@ lagoon add deploytarget-config [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_add_deploytarget.md
+++ b/docs/commands/lagoon_add_deploytarget.md
@@ -30,18 +30,21 @@ lagoon add deploytarget [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_add_group.md
+++ b/docs/commands/lagoon_add_group.md
@@ -23,18 +23,21 @@ lagoon add group [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_add_notification.md
+++ b/docs/commands/lagoon_add_notification.md
@@ -11,18 +11,21 @@ Add notifications or add notifications to projects
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_add_notification_email.md
+++ b/docs/commands/lagoon_add_notification_email.md
@@ -24,18 +24,21 @@ lagoon add notification email [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_add_notification_microsoftteams.md
+++ b/docs/commands/lagoon_add_notification_microsoftteams.md
@@ -24,18 +24,21 @@ lagoon add notification microsoftteams [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_add_notification_project-email.md
+++ b/docs/commands/lagoon_add_notification_project-email.md
@@ -21,18 +21,21 @@ lagoon add notification project-email [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_add_notification_project-microsoftteams.md
+++ b/docs/commands/lagoon_add_notification_project-microsoftteams.md
@@ -21,18 +21,21 @@ lagoon add notification project-microsoftteams [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_add_notification_project-rocketchat.md
+++ b/docs/commands/lagoon_add_notification_project-rocketchat.md
@@ -21,18 +21,21 @@ lagoon add notification project-rocketchat [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_add_notification_project-slack.md
+++ b/docs/commands/lagoon_add_notification_project-slack.md
@@ -21,18 +21,21 @@ lagoon add notification project-slack [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_add_notification_project-webhook.md
+++ b/docs/commands/lagoon_add_notification_project-webhook.md
@@ -21,18 +21,21 @@ lagoon add notification project-webhook [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_add_notification_rocketchat.md
+++ b/docs/commands/lagoon_add_notification_rocketchat.md
@@ -25,18 +25,21 @@ lagoon add notification rocketchat [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_add_notification_slack.md
+++ b/docs/commands/lagoon_add_notification_slack.md
@@ -25,18 +25,21 @@ lagoon add notification slack [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_add_notification_webhook.md
+++ b/docs/commands/lagoon_add_notification_webhook.md
@@ -24,18 +24,21 @@ lagoon add notification webhook [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_add_organization-administrator.md
+++ b/docs/commands/lagoon_add_organization-administrator.md
@@ -22,18 +22,21 @@ lagoon add organization-administrator [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_add_organization-deploytarget.md
+++ b/docs/commands/lagoon_add_organization-deploytarget.md
@@ -17,18 +17,21 @@ lagoon add organization-deploytarget [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_add_organization.md
+++ b/docs/commands/lagoon_add_organization.md
@@ -23,18 +23,21 @@ lagoon add organization [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_add_project-group.md
+++ b/docs/commands/lagoon_add_project-group.md
@@ -16,18 +16,21 @@ lagoon add project-group [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_add_project.md
+++ b/docs/commands/lagoon_add_project.md
@@ -38,18 +38,21 @@ lagoon add project [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_add_user-group.md
+++ b/docs/commands/lagoon_add_user-group.md
@@ -18,18 +18,21 @@ lagoon add user-group [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_add_user-sshkey.md
+++ b/docs/commands/lagoon_add_user-sshkey.md
@@ -38,18 +38,21 @@ lagoon add user-sshkey [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_add_user.md
+++ b/docs/commands/lagoon_add_user.md
@@ -19,18 +19,21 @@ lagoon add user [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_completion.md
+++ b/docs/commands/lagoon_completion.md
@@ -17,18 +17,21 @@ See each sub-command's help for details on how to use the generated script.
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_completion_bash.md
+++ b/docs/commands/lagoon_completion_bash.md
@@ -40,18 +40,21 @@ lagoon completion bash
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_completion_fish.md
+++ b/docs/commands/lagoon_completion_fish.md
@@ -31,18 +31,21 @@ lagoon completion fish [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_completion_powershell.md
+++ b/docs/commands/lagoon_completion_powershell.md
@@ -28,18 +28,21 @@ lagoon completion powershell [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_completion_zsh.md
+++ b/docs/commands/lagoon_completion_zsh.md
@@ -42,18 +42,21 @@ lagoon completion zsh [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_config.md
+++ b/docs/commands/lagoon_config.md
@@ -11,18 +11,21 @@ Configure Lagoon CLI
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_config_add.md
+++ b/docs/commands/lagoon_config_add.md
@@ -9,31 +9,35 @@ lagoon config add [flags]
 ### Options
 
 ```
-      --create-config     Create the config file if it is non existent (to be used with --config-file)
-  -g, --graphql string    Lagoon GraphQL endpoint
-  -h, --help              help for add
-  -H, --hostname string   Lagoon SSH hostname
-  -k, --kibana string     Lagoon Kibana URL (https://logs.amazeeio.cloud)
-  -P, --port string       Lagoon SSH port
-      --ssh-key string    SSH Key to use for this cluster for generating tokens
-  -t, --token string      Lagoon GraphQL token
-  -u, --ui string         Lagoon UI location (https://dashboard.amazeeio.cloud)
+      --create-config                    Create the config file if it is non existent (to be used with --config-file)
+  -g, --graphql string                   Lagoon GraphQL endpoint
+  -h, --help                             help for add
+  -H, --hostname string                  Lagoon SSH hostname
+  -k, --kibana string                    Lagoon Kibana URL (https://logs.amazeeio.cloud)
+  -P, --port string                      Lagoon SSH port
+      --publickey-identityfile strings   Specific public key identity files to use when doing ssh-agent checks (support multiple)
+      --ssh-key string                   SSH Key to use for this cluster for generating tokens
+  -t, --token string                     Lagoon GraphQL token
+  -u, --ui string                        Lagoon UI location (https://dashboard.amazeeio.cloud)
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_config_current.md
+++ b/docs/commands/lagoon_config_current.md
@@ -15,18 +15,21 @@ lagoon config current [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_config_default.md
+++ b/docs/commands/lagoon_config_default.md
@@ -15,18 +15,21 @@ lagoon config default [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_config_delete.md
+++ b/docs/commands/lagoon_config_delete.md
@@ -15,18 +15,21 @@ lagoon config delete [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_config_feature.md
+++ b/docs/commands/lagoon_config_feature.md
@@ -17,18 +17,21 @@ lagoon config feature [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_config_lagoon-version.md
+++ b/docs/commands/lagoon_config_lagoon-version.md
@@ -15,18 +15,21 @@ lagoon config lagoon-version [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_config_list.md
+++ b/docs/commands/lagoon_config_list.md
@@ -16,18 +16,21 @@ lagoon config list [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_delete.md
+++ b/docs/commands/lagoon_delete.md
@@ -11,18 +11,21 @@ Delete a project, or delete notifications and variables from projects or environ
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_delete_deploytarget-config.md
+++ b/docs/commands/lagoon_delete_deploytarget-config.md
@@ -16,18 +16,21 @@ lagoon delete deploytarget-config [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_delete_deploytarget.md
+++ b/docs/commands/lagoon_delete_deploytarget.md
@@ -21,18 +21,21 @@ lagoon delete deploytarget [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_delete_environment.md
+++ b/docs/commands/lagoon_delete_environment.md
@@ -15,18 +15,21 @@ lagoon delete environment [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_delete_group.md
+++ b/docs/commands/lagoon_delete_group.md
@@ -16,18 +16,21 @@ lagoon delete group [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_delete_notification.md
+++ b/docs/commands/lagoon_delete_notification.md
@@ -11,18 +11,21 @@ Delete notifications or delete notifications from projects
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_delete_notification_email.md
+++ b/docs/commands/lagoon_delete_notification_email.md
@@ -16,18 +16,21 @@ lagoon delete notification email [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_delete_notification_microsoftteams.md
+++ b/docs/commands/lagoon_delete_notification_microsoftteams.md
@@ -16,18 +16,21 @@ lagoon delete notification microsoftteams [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_delete_notification_project-email.md
+++ b/docs/commands/lagoon_delete_notification_project-email.md
@@ -16,18 +16,21 @@ lagoon delete notification project-email [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_delete_notification_project-microsoftteams.md
+++ b/docs/commands/lagoon_delete_notification_project-microsoftteams.md
@@ -16,18 +16,21 @@ lagoon delete notification project-microsoftteams [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_delete_notification_project-rocketchat.md
+++ b/docs/commands/lagoon_delete_notification_project-rocketchat.md
@@ -16,18 +16,21 @@ lagoon delete notification project-rocketchat [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_delete_notification_project-slack.md
+++ b/docs/commands/lagoon_delete_notification_project-slack.md
@@ -16,18 +16,21 @@ lagoon delete notification project-slack [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_delete_notification_project-webhook.md
+++ b/docs/commands/lagoon_delete_notification_project-webhook.md
@@ -16,18 +16,21 @@ lagoon delete notification project-webhook [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_delete_notification_rocketchat.md
+++ b/docs/commands/lagoon_delete_notification_rocketchat.md
@@ -16,18 +16,21 @@ lagoon delete notification rocketchat [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_delete_notification_slack.md
+++ b/docs/commands/lagoon_delete_notification_slack.md
@@ -16,18 +16,21 @@ lagoon delete notification slack [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_delete_notification_webhook.md
+++ b/docs/commands/lagoon_delete_notification_webhook.md
@@ -16,18 +16,21 @@ lagoon delete notification webhook [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_delete_organization-administrator.md
+++ b/docs/commands/lagoon_delete_organization-administrator.md
@@ -18,18 +18,21 @@ lagoon delete organization-administrator [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_delete_organization-deploytarget.md
+++ b/docs/commands/lagoon_delete_organization-deploytarget.md
@@ -17,18 +17,21 @@ lagoon delete organization-deploytarget [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_delete_organization-project.md
+++ b/docs/commands/lagoon_delete_organization-project.md
@@ -21,18 +21,21 @@ lagoon delete organization-project [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_delete_organization.md
+++ b/docs/commands/lagoon_delete_organization.md
@@ -16,18 +16,21 @@ lagoon delete organization [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_delete_project-group.md
+++ b/docs/commands/lagoon_delete_project-group.md
@@ -16,18 +16,21 @@ lagoon delete project-group [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_delete_project-metadata.md
+++ b/docs/commands/lagoon_delete_project-metadata.md
@@ -16,18 +16,21 @@ lagoon delete project-metadata [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_delete_project.md
+++ b/docs/commands/lagoon_delete_project.md
@@ -15,18 +15,21 @@ lagoon delete project [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_delete_user-group.md
+++ b/docs/commands/lagoon_delete_user-group.md
@@ -17,18 +17,21 @@ lagoon delete user-group [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_delete_user-sshkey.md
+++ b/docs/commands/lagoon_delete_user-sshkey.md
@@ -16,18 +16,21 @@ lagoon delete user-sshkey [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_delete_user.md
+++ b/docs/commands/lagoon_delete_user.md
@@ -16,18 +16,21 @@ lagoon delete user [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_delete_variable.md
+++ b/docs/commands/lagoon_delete_variable.md
@@ -20,18 +20,21 @@ lagoon delete variable [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_deploy.md
+++ b/docs/commands/lagoon_deploy.md
@@ -11,18 +11,21 @@ Actions for deploying or promoting branches or environments in lagoon
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_deploy_branch.md
+++ b/docs/commands/lagoon_deploy_branch.md
@@ -25,18 +25,21 @@ lagoon deploy branch [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_deploy_latest.md
+++ b/docs/commands/lagoon_deploy_latest.md
@@ -22,18 +22,21 @@ lagoon deploy latest [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_deploy_promote.md
+++ b/docs/commands/lagoon_deploy_promote.md
@@ -23,18 +23,21 @@ lagoon deploy promote [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_deploy_pullrequest.md
+++ b/docs/commands/lagoon_deploy_pullrequest.md
@@ -28,18 +28,21 @@ lagoon deploy pullrequest [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_export.md
+++ b/docs/commands/lagoon_export.md
@@ -21,18 +21,21 @@ lagoon export [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_get.md
+++ b/docs/commands/lagoon_get.md
@@ -11,18 +11,21 @@ Get info on a resource
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_get_all-user-sshkeys.md
+++ b/docs/commands/lagoon_get_all-user-sshkeys.md
@@ -20,18 +20,21 @@ lagoon get all-user-sshkeys [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_get_backup.md
+++ b/docs/commands/lagoon_get_backup.md
@@ -21,18 +21,21 @@ lagoon get backup [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_get_deployment.md
+++ b/docs/commands/lagoon_get_deployment.md
@@ -22,18 +22,21 @@ lagoon get deployment [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_get_environment.md
+++ b/docs/commands/lagoon_get_environment.md
@@ -15,18 +15,21 @@ lagoon get environment [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_get_organization.md
+++ b/docs/commands/lagoon_get_organization.md
@@ -16,18 +16,21 @@ lagoon get organization [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_get_project-key.md
+++ b/docs/commands/lagoon_get_project-key.md
@@ -16,18 +16,21 @@ lagoon get project-key [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_get_project-metadata.md
+++ b/docs/commands/lagoon_get_project-metadata.md
@@ -15,18 +15,21 @@ lagoon get project-metadata [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_get_project.md
+++ b/docs/commands/lagoon_get_project.md
@@ -15,18 +15,21 @@ lagoon get project [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_get_task-by-id.md
+++ b/docs/commands/lagoon_get_task-by-id.md
@@ -21,18 +21,21 @@ lagoon get task-by-id [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_get_token.md
+++ b/docs/commands/lagoon_get_token.md
@@ -15,18 +15,21 @@ lagoon get token [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_get_user-sshkeys.md
+++ b/docs/commands/lagoon_get_user-sshkeys.md
@@ -20,18 +20,21 @@ lagoon get user-sshkeys [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_import.md
+++ b/docs/commands/lagoon_import.md
@@ -24,18 +24,21 @@ lagoon import [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_kibana.md
+++ b/docs/commands/lagoon_kibana.md
@@ -15,18 +15,21 @@ lagoon kibana [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_list.md
+++ b/docs/commands/lagoon_list.md
@@ -12,18 +12,21 @@ List projects, environments, deployments, variables or notifications
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_list_all-users.md
+++ b/docs/commands/lagoon_list_all-users.md
@@ -21,18 +21,21 @@ lagoon list all-users [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_list_backups.md
+++ b/docs/commands/lagoon_list_backups.md
@@ -15,18 +15,21 @@ lagoon list backups [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_list_deployments.md
+++ b/docs/commands/lagoon_list_deployments.md
@@ -15,18 +15,21 @@ lagoon list deployments [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_list_deploytarget-configs.md
+++ b/docs/commands/lagoon_list_deploytarget-configs.md
@@ -15,18 +15,21 @@ lagoon list deploytarget-configs [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_list_deploytargets.md
+++ b/docs/commands/lagoon_list_deploytargets.md
@@ -19,18 +19,21 @@ lagoon list deploytargets [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_list_environments.md
+++ b/docs/commands/lagoon_list_environments.md
@@ -15,18 +15,21 @@ lagoon list environments [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_list_group-projects.md
+++ b/docs/commands/lagoon_list_group-projects.md
@@ -17,18 +17,21 @@ lagoon list group-projects [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_list_group-users.md
+++ b/docs/commands/lagoon_list_group-users.md
@@ -22,18 +22,21 @@ lagoon list group-users [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_list_groups.md
+++ b/docs/commands/lagoon_list_groups.md
@@ -15,18 +15,21 @@ lagoon list groups [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_list_invokable-tasks.md
+++ b/docs/commands/lagoon_list_invokable-tasks.md
@@ -19,18 +19,21 @@ lagoon list invokable-tasks [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_list_notification.md
+++ b/docs/commands/lagoon_list_notification.md
@@ -11,18 +11,21 @@ List all notifications or notifications on projects
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_list_notification_email.md
+++ b/docs/commands/lagoon_list_notification_email.md
@@ -15,18 +15,21 @@ lagoon list notification email [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_list_notification_microsoftteams.md
+++ b/docs/commands/lagoon_list_notification_microsoftteams.md
@@ -15,18 +15,21 @@ lagoon list notification microsoftteams [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_list_notification_project-email.md
+++ b/docs/commands/lagoon_list_notification_project-email.md
@@ -15,18 +15,21 @@ lagoon list notification project-email [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_list_notification_project-microsoftteams.md
+++ b/docs/commands/lagoon_list_notification_project-microsoftteams.md
@@ -15,18 +15,21 @@ lagoon list notification project-microsoftteams [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_list_notification_project-rocketchat.md
+++ b/docs/commands/lagoon_list_notification_project-rocketchat.md
@@ -15,18 +15,21 @@ lagoon list notification project-rocketchat [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_list_notification_project-slack.md
+++ b/docs/commands/lagoon_list_notification_project-slack.md
@@ -15,18 +15,21 @@ lagoon list notification project-slack [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_list_notification_project-webhook.md
+++ b/docs/commands/lagoon_list_notification_project-webhook.md
@@ -15,18 +15,21 @@ lagoon list notification project-webhook [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_list_notification_rocketchat.md
+++ b/docs/commands/lagoon_list_notification_rocketchat.md
@@ -15,18 +15,21 @@ lagoon list notification rocketchat [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_list_notification_slack.md
+++ b/docs/commands/lagoon_list_notification_slack.md
@@ -15,18 +15,21 @@ lagoon list notification slack [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_list_notification_webhook.md
+++ b/docs/commands/lagoon_list_notification_webhook.md
@@ -15,18 +15,21 @@ lagoon list notification webhook [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_list_organization-deploytargets.md
+++ b/docs/commands/lagoon_list_organization-deploytargets.md
@@ -17,18 +17,21 @@ lagoon list organization-deploytargets [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_list_organization-groups.md
+++ b/docs/commands/lagoon_list_organization-groups.md
@@ -16,18 +16,21 @@ lagoon list organization-groups [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_list_organization-projects.md
+++ b/docs/commands/lagoon_list_organization-projects.md
@@ -16,18 +16,21 @@ lagoon list organization-projects [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_list_organization-users.md
+++ b/docs/commands/lagoon_list_organization-users.md
@@ -16,18 +16,21 @@ lagoon list organization-users [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_list_organizations.md
+++ b/docs/commands/lagoon_list_organizations.md
@@ -15,18 +15,21 @@ lagoon list organizations [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_list_project-groups.md
+++ b/docs/commands/lagoon_list_project-groups.md
@@ -15,18 +15,21 @@ lagoon list project-groups [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_list_projects-by-metadata.md
+++ b/docs/commands/lagoon_list_projects-by-metadata.md
@@ -18,18 +18,21 @@ lagoon list projects-by-metadata [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_list_projects.md
+++ b/docs/commands/lagoon_list_projects.md
@@ -15,18 +15,21 @@ lagoon list projects [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_list_tasks.md
+++ b/docs/commands/lagoon_list_tasks.md
@@ -15,18 +15,21 @@ lagoon list tasks [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_list_user-groups.md
+++ b/docs/commands/lagoon_list_user-groups.md
@@ -20,18 +20,21 @@ lagoon list user-groups [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_list_variables.md
+++ b/docs/commands/lagoon_list_variables.md
@@ -16,18 +16,21 @@ lagoon list variables [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_login.md
+++ b/docs/commands/lagoon_login.md
@@ -15,18 +15,21 @@ lagoon login [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_logs.md
+++ b/docs/commands/lagoon_logs.md
@@ -19,18 +19,21 @@ lagoon logs [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_raw.md
+++ b/docs/commands/lagoon_raw.md
@@ -21,18 +21,21 @@ lagoon raw [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_reset-password.md
+++ b/docs/commands/lagoon_reset-password.md
@@ -16,18 +16,21 @@ lagoon reset-password [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_retrieve.md
+++ b/docs/commands/lagoon_retrieve.md
@@ -11,18 +11,21 @@ Trigger a retrieval operation on backups
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_retrieve_backup.md
+++ b/docs/commands/lagoon_retrieve_backup.md
@@ -22,18 +22,21 @@ lagoon retrieve backup [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_run.md
+++ b/docs/commands/lagoon_run.md
@@ -11,18 +11,21 @@ Run a task against an environment
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_run_activestandby.md
+++ b/docs/commands/lagoon_run_activestandby.md
@@ -21,18 +21,21 @@ lagoon run activestandby [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_run_custom.md
+++ b/docs/commands/lagoon_run_custom.md
@@ -33,18 +33,21 @@ lagoon run custom [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_run_drush-archivedump.md
+++ b/docs/commands/lagoon_run_drush-archivedump.md
@@ -15,18 +15,21 @@ lagoon run drush-archivedump [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_run_drush-cacheclear.md
+++ b/docs/commands/lagoon_run_drush-cacheclear.md
@@ -15,18 +15,21 @@ lagoon run drush-cacheclear [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_run_drush-sqldump.md
+++ b/docs/commands/lagoon_run_drush-sqldump.md
@@ -15,18 +15,21 @@ lagoon run drush-sqldump [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_run_invoke.md
+++ b/docs/commands/lagoon_run_invoke.md
@@ -24,18 +24,21 @@ lagoon run invoke [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_ssh.md
+++ b/docs/commands/lagoon_ssh.md
@@ -19,18 +19,21 @@ lagoon ssh [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_update.md
+++ b/docs/commands/lagoon_update.md
@@ -11,18 +11,21 @@ Update a resource
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_update_deploytarget-config.md
+++ b/docs/commands/lagoon_update_deploytarget-config.md
@@ -20,18 +20,21 @@ lagoon update deploytarget-config [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_update_deploytarget.md
+++ b/docs/commands/lagoon_update_deploytarget.md
@@ -29,18 +29,21 @@ lagoon update deploytarget [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_update_environment.md
+++ b/docs/commands/lagoon_update_environment.md
@@ -25,18 +25,21 @@ lagoon update environment [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_update_notification.md
+++ b/docs/commands/lagoon_update_notification.md
@@ -11,18 +11,21 @@ List all notifications or notifications on projects
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_update_notification_email.md
+++ b/docs/commands/lagoon_update_notification_email.md
@@ -18,18 +18,21 @@ lagoon update notification email [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_update_notification_microsoftteams.md
+++ b/docs/commands/lagoon_update_notification_microsoftteams.md
@@ -18,18 +18,21 @@ lagoon update notification microsoftteams [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_update_notification_rocketchat.md
+++ b/docs/commands/lagoon_update_notification_rocketchat.md
@@ -19,18 +19,21 @@ lagoon update notification rocketchat [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_update_notification_slack.md
+++ b/docs/commands/lagoon_update_notification_slack.md
@@ -19,18 +19,21 @@ lagoon update notification slack [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_update_notification_webhook.md
+++ b/docs/commands/lagoon_update_notification_webhook.md
@@ -18,18 +18,21 @@ lagoon update notification webhook [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_update_organization.md
+++ b/docs/commands/lagoon_update_organization.md
@@ -23,18 +23,21 @@ lagoon update organization [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_update_project-metadata.md
+++ b/docs/commands/lagoon_update_project-metadata.md
@@ -17,18 +17,21 @@ lagoon update project-metadata [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_update_project.md
+++ b/docs/commands/lagoon_update_project.md
@@ -37,18 +37,21 @@ lagoon update project [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_update_user.md
+++ b/docs/commands/lagoon_update_user.md
@@ -23,18 +23,21 @@ lagoon update user [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_update_variable.md
+++ b/docs/commands/lagoon_update_variable.md
@@ -18,18 +18,21 @@ lagoon update variable [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_upload.md
+++ b/docs/commands/lagoon_upload.md
@@ -11,18 +11,21 @@ Upload files to tasks
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_upload_task-files.md
+++ b/docs/commands/lagoon_upload_task-files.md
@@ -21,18 +21,21 @@ lagoon upload task-files [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_version.md
+++ b/docs/commands/lagoon_version.md
@@ -15,18 +15,21 @@ lagoon version [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_web.md
+++ b/docs/commands/lagoon_web.md
@@ -15,18 +15,21 @@ lagoon web [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/docs/commands/lagoon_whoami.md
+++ b/docs/commands/lagoon_whoami.md
@@ -21,18 +21,21 @@ lagoon whoami [flags]
 ### Options inherited from parent commands
 
 ```
-      --config-file string   Path to the config file to use (must be *.yml or *.yaml)
-      --debug                Enable debugging output (if supported)
-  -e, --environment string   Specify an environment to use
-      --force                Force yes on prompts (if supported)
-  -l, --lagoon string        The Lagoon instance to interact with
-      --no-header            No header on table (if supported)
-      --output-csv           Output as CSV (if supported)
-      --output-json          Output as JSON (if supported)
-      --pretty               Make JSON pretty (if supported)
-  -p, --project string       Specify a project to use
-      --skip-update-check    Skip checking for updates
-  -i, --ssh-key string       Specify path to a specific SSH key to use for lagoon authentication
+      --config-file string     Path to the config file to use (must be *.yml or *.yaml)
+      --debug                  Enable debugging output (if supported)
+  -e, --environment string     Specify an environment to use
+      --force                  Force yes on prompts (if supported)
+  -l, --lagoon string          The Lagoon instance to interact with
+      --no-header              No header on table (if supported)
+      --output-csv             Output as CSV (if supported)
+      --output-json            Output as JSON (if supported)
+      --pretty                 Make JSON pretty (if supported)
+  -p, --project string         Specify a project to use
+      --skip-update-check      Skip checking for updates
+  -i, --ssh-key string         Specify path to a specific SSH key to use for lagoon authentication
+      --ssh-publickey string   Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
+                               This will override any public key identities defined in configuration
+  -v, --verbose                Enable verbose output to stderr (if supported)
 ```
 
 ### SEE ALSO

--- a/internal/lagoon/config.go
+++ b/internal/lagoon/config.go
@@ -11,13 +11,14 @@ type Config struct {
 
 // Context is used for each lagoon context in the config file.
 type Context struct {
-	GraphQL   string `json:"graphql"`
-	HostName  string `json:"hostname"`
-	UI        string `json:"ui,omitempty"`
-	Kibana    string `json:"kibana,omitempty"`
-	Port      string `json:"port"`
-	Token     string `json:"token,omitempty"`
-	Version   string `json:"version,omitempty"`
-	SSHKey    string `json:"sshkey,omitempty"`
-	SSHPortal bool   `json:"sshPortal,omitempty"`
+	GraphQL             string   `json:"graphql"`
+	HostName            string   `json:"hostname"`
+	UI                  string   `json:"ui,omitempty"`
+	Kibana              string   `json:"kibana,omitempty"`
+	Port                string   `json:"port"`
+	Token               string   `json:"token,omitempty"`
+	Version             string   `json:"version,omitempty"`
+	SSHKey              string   `json:"sshkey,omitempty"`
+	SSHPortal           bool     `json:"sshPortal,omitempty"`
+	PublicKeyIdentities []string `json:"publickeyidentities,omitempty"`
 }


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

This adds support for publickey identities to the config file, which allows for these to select a key if it is found in the ssh-agent
```
lagoons:
    local-k3d:
        publickeyidentities:
          - /full/path/to/key.pub
```
A flag can be provided too `--ssh-publickey /full/path/to/key.pub` which will override anything defined in configuration

Additionally, a global `--verbose` flag is added which can be used to print some verbose output to stderr, this could be used elsewhere in the CLI in the future too. In this PR the flag will print which key is being used or if the agent is being used, which can help users with debugging.

Worth noting, once #319 is finalized, keycloak authentication will be the preferred method for authenticating the CLI to get a token, leaving these identity files to only be used for the `ssh` aspect the CLI provides. But they can still be used for authenticating to get a token via the SSH service still.

# Closing issues

closes #354 