### PR TITLE
chore: update remaining flags, docs, and remove most openshift references

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -41,7 +41,7 @@ use 'lagoon deploy latest' instead`,
 		if err != nil {
 			return err
 		}
-		returnData, err := cmd.Flags().GetBool("returnData")
+		returnData, err := cmd.Flags().GetBool("returndata")
 		if err != nil {
 			return err
 		}
@@ -107,7 +107,7 @@ var deployPromoteCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		returnData, err := cmd.Flags().GetBool("returnData")
+		returnData, err := cmd.Flags().GetBool("returndata")
 		if err != nil {
 			return err
 		}
@@ -161,7 +161,7 @@ This environment should already exist in lagoon. It is analogous with the 'Deplo
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 
-		returnData, err := cmd.Flags().GetBool("returnData")
+		returnData, err := cmd.Flags().GetBool("returndata")
 		if err != nil {
 			return err
 		}
@@ -233,23 +233,23 @@ This pullrequest may not already exist as an environment in lagoon.`,
 		if err != nil {
 			return err
 		}
-		baseBranchName, err := cmd.Flags().GetString("baseBranchName")
+		baseBranchName, err := cmd.Flags().GetString("base-branch-name")
 		if err != nil {
 			return err
 		}
-		baseBranchRef, err := cmd.Flags().GetString("baseBranchRef")
+		baseBranchRef, err := cmd.Flags().GetString("base-branch-ref")
 		if err != nil {
 			return err
 		}
-		headBranchName, err := cmd.Flags().GetString("headBranchName")
+		headBranchName, err := cmd.Flags().GetString("head-branch-name")
 		if err != nil {
 			return err
 		}
-		headBranchRef, err := cmd.Flags().GetString("headBranchRef")
+		headBranchRef, err := cmd.Flags().GetString("head-branch-ref")
 		if err != nil {
 			return err
 		}
-		if err := requiredInputCheck("Project name", cmdProjectName, "Pullrequest title", prTitle, "Pullrequest number", strconv.Itoa(int(prNumber)), "baseBranchName", baseBranchName, "baseBranchRef", baseBranchRef, "headBranchName", headBranchName, "headBranchRef", headBranchRef); err != nil {
+		if err := requiredInputCheck("Project name", cmdProjectName, "Pullrequest title", prTitle, "Pullrequest number", strconv.Itoa(int(prNumber)), "Base branch name", baseBranchName, "Base branch ref", baseBranchRef, "Head branch name", headBranchName, "Head branch ref", headBranchRef); err != nil {
 			return err
 		}
 		buildVarStrings, err := cmd.Flags().GetStringArray("buildvar")
@@ -261,7 +261,7 @@ This pullrequest may not already exist as an environment in lagoon.`,
 			return err
 		}
 
-		returnData, err := cmd.Flags().GetBool("returnData")
+		returnData, err := cmd.Flags().GetBool("returndata")
 		if err != nil {
 			return err
 		}
@@ -304,25 +304,25 @@ func init() {
 	deployCmd.AddCommand(deployPullrequestCmd)
 
 	const returnDataUsageText = "Returns the build name instead of success text"
-	deployLatestCmd.Flags().Bool("returnData", false, returnDataUsageText)
+	deployLatestCmd.Flags().Bool("returndata", false, returnDataUsageText)
 	deployLatestCmd.Flags().StringArray("buildvar", []string{}, "Add one or more build variables to deployment (--buildvar KEY1=VALUE1 [--buildvar KEY2=VALUE2])")
 
 	deployBranchCmd.Flags().StringP("branch", "b", "", "Branch name to deploy")
-	deployBranchCmd.Flags().StringP("branchRef", "r", "", "Branch ref to deploy")
-	deployBranchCmd.Flags().Bool("returnData", false, returnDataUsageText)
+	deployBranchCmd.Flags().StringP("branch-ref", "r", "", "Branch ref to deploy")
+	deployBranchCmd.Flags().Bool("returndata", false, returnDataUsageText)
 	deployBranchCmd.Flags().StringArray("buildvar", []string{}, "Add one or more build variables to deployment (--buildvar KEY1=VALUE1 [--buildvar KEY2=VALUE2])")
 
 	deployPromoteCmd.Flags().StringP("destination", "d", "", "Destination environment name to create")
 	deployPromoteCmd.Flags().StringP("source", "s", "", "Source environment name to use as the base to deploy from")
-	deployPromoteCmd.Flags().Bool("returnData", false, returnDataUsageText)
+	deployPromoteCmd.Flags().Bool("returndata", false, returnDataUsageText)
 	deployPromoteCmd.Flags().StringArray("buildvar", []string{}, "Add one or more build variables to deployment (--buildvar KEY1=VALUE1 [--buildvar KEY2=VALUE2])")
 
 	deployPullrequestCmd.Flags().StringP("title", "t", "", "Pullrequest title")
 	deployPullrequestCmd.Flags().UintP("number", "n", 0, "Pullrequest number")
-	deployPullrequestCmd.Flags().StringP("baseBranchName", "N", "", "Pullrequest base branch name")
-	deployPullrequestCmd.Flags().StringP("baseBranchRef", "R", "", "Pullrequest base branch reference hash")
-	deployPullrequestCmd.Flags().StringP("headBranchName", "H", "", "Pullrequest head branch name")
-	deployPullrequestCmd.Flags().StringP("headBranchRef", "M", "", "Pullrequest head branch reference hash")
-	deployPullrequestCmd.Flags().Bool("returnData", false, returnDataUsageText)
+	deployPullrequestCmd.Flags().StringP("base-branch-name", "N", "", "Pullrequest base branch name")
+	deployPullrequestCmd.Flags().StringP("base-branch-ref", "R", "", "Pullrequest base branch reference hash")
+	deployPullrequestCmd.Flags().StringP("head-branch-name", "H", "", "Pullrequest head branch name")
+	deployPullrequestCmd.Flags().StringP("head-branch-ref", "M", "", "Pullrequest head branch reference hash")
+	deployPullrequestCmd.Flags().Bool("returndata", false, returnDataUsageText)
 	deployPullrequestCmd.Flags().StringArray("buildvar", []string{}, "Add one or more build variables to deployment (--buildvar KEY1=VALUE1 [--buildvar KEY2=VALUE2])")
 }

--- a/cmd/deploytarget.go
+++ b/cmd/deploytarget.go
@@ -16,7 +16,7 @@ var addDeployTargetCmd = &cobra.Command{
 	Use:     "deploytarget",
 	Aliases: []string{"dt"},
 	Short:   "Add a DeployTarget to lagoon",
-	Long:    "Add a DeployTarget (kubernetes or openshift) to lagoon, this requires admin level permissions",
+	Long:    "Add a Deploytarget(Kubernetes) to lagoon, this requires admin level permissions",
 	PreRunE: func(_ *cobra.Command, _ []string) error {
 		return validateTokenE(cmdLagoon)
 	},
@@ -147,7 +147,7 @@ var updateDeployTargetCmd = &cobra.Command{
 	Use:     "deploytarget",
 	Aliases: []string{"dt"},
 	Short:   "Update a DeployTarget in lagoon",
-	Long:    "Update a DeployTarget (kubernetes or openshift) in lagoon, this requires admin level permissions",
+	Long:    "Update a Deploytarget(Kubernetes) in lagoon, this requires admin level permissions",
 	PreRunE: func(_ *cobra.Command, _ []string) error {
 		return validateTokenE(cmdLagoon)
 	},
@@ -279,7 +279,7 @@ var deleteDeployTargetCmd = &cobra.Command{
 	Use:     "deploytarget",
 	Aliases: []string{"dt"},
 	Short:   "Delete a DeployTarget from lagoon",
-	Long:    "Delete a DeployTarget (kubernetes or openshift) from lagoon, this requires admin level permissions",
+	Long:    "Delete a Deploytarget(Kubernetes) from lagoon, this requires admin level permissions",
 	PreRunE: func(_ *cobra.Command, _ []string) error {
 		return validateTokenE(cmdLagoon)
 	},

--- a/cmd/environment.go
+++ b/cmd/environment.go
@@ -96,7 +96,7 @@ var updateEnvironmentCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		openShift, err := cmd.Flags().GetUint("deploytarget")
+		deploytarget, err := cmd.Flags().GetUint("deploytarget")
 		if err != nil {
 			return err
 		}
@@ -141,7 +141,7 @@ var updateEnvironmentCmd = &cobra.Command{
 			Route:                nullStrCheck(route),
 			Routes:               nullStrCheck(routes),
 			DeployTitle:          nullStrCheck(deployTitle),
-			Openshift:            nullUintCheck(openShift),
+			Openshift:            nullUintCheck(deploytarget),
 		}
 		if environmentAutoIdleProvided {
 			environmentFlags.AutoIdle = &environmentAutoIdle
@@ -313,7 +313,7 @@ func init() {
 	updateEnvironmentCmd.Flags().String("route", "", "Update the route for the selected environment")
 	updateEnvironmentCmd.Flags().String("routes", "", "Update the routes for the selected environment")
 	updateEnvironmentCmd.Flags().UintVarP(&environmentAutoIdle, "auto-idle", "a", 1, "Auto idle setting of the environment")
-	updateEnvironmentCmd.Flags().UintP("deploytarget", "d", 0, "Reference to OpenShift Object this Environment should be deployed to")
+	updateEnvironmentCmd.Flags().UintP("deploytarget", "d", 0, "Reference to Deploytarget(Kubernetes) this Environment should be deployed to")
 	updateEnvironmentCmd.Flags().String("environment-type", "", "Update the environment type - production | development")
 	updateEnvironmentCmd.Flags().String("deploy-type", "", "Update the deploy type - branch | pullrequest | promote")
 }

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -241,7 +241,7 @@ var getEnvironmentCmd = &cobra.Command{
 			returnNonEmptyString(fmt.Sprintf("%v", environment.DeployHeadRef)),
 		})
 		dataMain := output.Table{
-			Header: []string{"ID", "EnvironmentName", "EnvironmentType", "DeployType", "Created", "OpenshiftProjectName", "Route", "Routes", "AutoIdle", "DeployTitle", "DeployBaseRef", "DeployHeadRef"},
+			Header: []string{"ID", "EnvironmentName", "EnvironmentType", "DeployType", "Created", "Namespace", "Route", "Routes", "AutoIdle", "DeployTitle", "DeployBaseRef", "DeployHeadRef"},
 			Data:   data,
 		}
 		output.RenderOutput(dataMain, outputOptions)

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -30,7 +30,7 @@ You can get it to continue anyway with --keep-going. To disable any prompts, use
 		if err != nil {
 			return err
 		}
-		openshiftID, err := cmd.Flags().GetUint("openshiftID")
+		deploytargetID, err := cmd.Flags().GetUint("deploytarget-id")
 		if err != nil {
 			return err
 		}
@@ -62,7 +62,7 @@ You can get it to continue anyway with --keep-going. To disable any prompts, use
 			return fmt.Errorf("couldn't open file: %w", err)
 		}
 
-		return lagoon.Import(context.TODO(), lc, file, keepGoing, openshiftID)
+		return lagoon.Import(context.TODO(), lc, file, keepGoing, deploytargetID)
 	},
 }
 
@@ -136,9 +136,9 @@ func init() {
 		"path to the file to import")
 	importCmd.Flags().Bool("keep-going", false,
 		"on error, just log and continue instead of aborting")
-	importCmd.Flags().Uint("openshiftID", 0,
-		"ID of the openshift to target for import")
-	for _, flag := range []string{"import-file", "openshiftID"} {
+	importCmd.Flags().Uint("deploytarget-id", 0,
+		"ID of the deploytarget to target for import")
+	for _, flag := range []string{"import-file", "deploytarget-id"} {
 		if err := importCmd.MarkFlagRequired(flag); err != nil {
 			panic(err)
 		}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -87,7 +87,7 @@ var listDeployTargetsCmd = &cobra.Command{
 	Use:     "deploytargets",
 	Aliases: []string{"deploytarget", "dt"},
 	Short:   "List all DeployTargets in Lagoon",
-	Long:    "List all DeployTargets (kubernetes or openshift) in lagoon, this requires admin level permissions",
+	Long:    "List all Deploytargets(Kubernetes) in lagoon, this requires admin level permissions",
 	PreRunE: func(_ *cobra.Command, _ []string) error {
 		return validateTokenE(cmdLagoon)
 	},

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -86,7 +86,7 @@ var addProjectCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		openshift, err := cmd.Flags().GetUint("openshift")
+		deploytarget, err := cmd.Flags().GetUint("deploytarget")
 		if err != nil {
 			return err
 		}
@@ -102,7 +102,7 @@ var addProjectCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		openshiftProjectPattern, err := cmd.Flags().GetString("openshift-project-pattern")
+		deploytargetProjectPattern, err := cmd.Flags().GetString("deploytarget-project-pattern")
 		if err != nil {
 			return err
 		}
@@ -139,7 +139,7 @@ var addProjectCmd = &cobra.Command{
 			return err
 		}
 
-		if err := requiredInputCheck("Project name", cmdProjectName, "git-url", gitUrl, "Production environment", productionEnvironment, "Openshift", strconv.Itoa(int(openshift))); err != nil {
+		if err := requiredInputCheck("Project name", cmdProjectName, "git-url", gitUrl, "Production environment", productionEnvironment, "Deploytarget", strconv.Itoa(int(deploytarget))); err != nil {
 			return err
 		}
 
@@ -160,8 +160,8 @@ var addProjectCmd = &cobra.Command{
 			StandbyProductionEnvironment: standbyProductionEnvironment,
 			Branches:                     branches,
 			PullRequests:                 pullrequests,
-			OpenshiftProjectPattern:      openshiftProjectPattern,
-			Openshift:                    openshift,
+			OpenshiftProjectPattern:      deploytargetProjectPattern,
+			Openshift:                    deploytarget,
 			DevelopmentEnvironmentsLimit: developmentEnvironmentsLimit,
 			StorageCalc:                  storageCalc,
 			AutoIdle:                     autoIdle,
@@ -232,7 +232,7 @@ var updateProjectCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		openshift, err := cmd.Flags().GetUint("openshift")
+		deploytarget, err := cmd.Flags().GetUint("deploytarget")
 		if err != nil {
 			return err
 		}
@@ -248,7 +248,7 @@ var updateProjectCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		openshiftProjectPattern, err := cmd.Flags().GetString("openshift-project-pattern")
+		deploytargetProjectPattern, err := cmd.Flags().GetString("deploytarget-project-pattern")
 		if err != nil {
 			return err
 		}
@@ -326,11 +326,11 @@ var updateProjectCmd = &cobra.Command{
 		projectPatch := schema.UpdateProjectPatchInput{
 			GitURL:                       nullStrCheck(gitUrl),
 			ProductionEnvironment:        nullStrCheck(productionEnvironment),
-			Openshift:                    nullUintCheck(openshift),
+			Openshift:                    nullUintCheck(deploytarget),
 			StandbyProductionEnvironment: nullStrCheck(standbyProductionEnvironment),
 			Branches:                     nullStrCheck(branches),
 			Pullrequests:                 nullStrCheck(pullrequests),
-			OpenshiftProjectPattern:      nullStrCheck(openshiftProjectPattern),
+			OpenshiftProjectPattern:      nullStrCheck(deploytargetProjectPattern),
 			DevelopmentEnvironmentsLimit: nullUintCheck(developmentEnvironmentsLimit),
 			StorageCalc:                  nullUintCheck(storageCalc),
 			AutoIdle:                     nullUintCheck(autoIdle),
@@ -713,7 +713,7 @@ func init() {
 	updateProjectCmd.Flags().StringP("pullrequests", "m", "", "Which Pull Requests should be deployed")
 	updateProjectCmd.Flags().StringP("production-environment", "E", "", "Which environment(the name) should be marked as the production environment")
 	updateProjectCmd.Flags().String("standby-production-environment", "", "Which environment(the name) should be marked as the standby production environment")
-	updateProjectCmd.Flags().StringP("openshift-project-pattern", "o", "", "Pattern of OpenShift Project/Namespace that should be generated")
+	updateProjectCmd.Flags().StringP("deploytarget-project-pattern", "o", "", "Pattern of Deploytarget(Kubernetes) Project/Namespace that should be generated")
 	updateProjectCmd.Flags().StringP("build-image", "", "", "Build Image for the project. Set to 'null' to remove the build image")
 	updateProjectCmd.Flags().StringP("availability", "", "", "Availability of the project")
 
@@ -722,7 +722,7 @@ func init() {
 	updateProjectCmd.Flags().UintP("auto-idle", "a", 0, "Auto idle setting of the project")
 	updateProjectCmd.Flags().UintP("storage-calc", "C", 0, "Should storage for this environment be calculated")
 	updateProjectCmd.Flags().UintP("development-environments-limit", "L", 0, "How many environments can be deployed at one time")
-	updateProjectCmd.Flags().UintP("openshift", "S", 0, "Reference to OpenShift Object this Project should be deployed to")
+	updateProjectCmd.Flags().UintP("deploytarget", "S", 0, "Reference to Deploytarget(Kubernetes) this Project should be deployed to")
 	updateProjectCmd.Flags().UintP("deployments-disabled", "", 0, "Admin only flag for disabling deployments on a project, 1 to disable deployments, 0 to enable")
 
 	updateProjectCmd.Flags().UintP("facts-ui", "", 0, "Enables the Lagoon insights Facts tab in the UI. Set to 1 to enable, 0 to disable")
@@ -738,12 +738,12 @@ func init() {
 	addProjectCmd.Flags().StringP("pullrequests", "m", "", "Which Pull Requests should be deployed")
 	addProjectCmd.Flags().StringP("production-environment", "E", "", "Which environment(the name) should be marked as the production environment")
 	addProjectCmd.Flags().String("standby-production-environment", "", "Which environment(the name) should be marked as the standby production environment")
-	addProjectCmd.Flags().StringP("openshift-project-pattern", "o", "", "Pattern of OpenShift Project/Namespace that should be generated")
+	addProjectCmd.Flags().StringP("deploytarget-project-pattern", "", "", "Pattern of Deploytarget(Kubernetes) Project/Namespace that should be generated")
 
 	addProjectCmd.Flags().UintP("auto-idle", "a", 0, "Auto idle setting of the project")
 	addProjectCmd.Flags().UintP("storage-calc", "C", 0, "Should storage for this environment be calculated")
 	addProjectCmd.Flags().UintP("development-environments-limit", "L", 0, "How many environments can be deployed at one time")
-	addProjectCmd.Flags().UintP("openshift", "S", 0, "Reference to OpenShift Object this Project should be deployed to")
+	addProjectCmd.Flags().UintP("deploytarget", "S", 0, "Reference to Deploytarget(Kubernetes) target this Project should be deployed to")
 	addProjectCmd.Flags().StringP("build-image", "", "", "Build Image for the project")
 	addProjectCmd.Flags().Bool("owner", false, "Add the user as an owner of the project")
 	addProjectCmd.Flags().StringP("organization-name", "O", "", "Name of the Organization to add the project to")

--- a/docs/commands/lagoon.md
+++ b/docs/commands/lagoon.md
@@ -42,6 +42,7 @@ lagoon [flags]
 * [lagoon kibana](lagoon_kibana.md)	 - Launch the kibana interface
 * [lagoon list](lagoon_list.md)	 - List projects, environments, deployments, variables or notifications
 * [lagoon login](lagoon_login.md)	 - Log into a Lagoon instance
+* [lagoon logs](lagoon_logs.md)	 - Display logs for a service of an environment and project
 * [lagoon raw](lagoon_raw.md)	 - Run a custom query or mutation
 * [lagoon reset-password](lagoon_reset-password.md)	 - Send a password reset email
 * [lagoon retrieve](lagoon_retrieve.md)	 - Trigger a retrieval operation on backups

--- a/docs/commands/lagoon_add_deploytarget.md
+++ b/docs/commands/lagoon_add_deploytarget.md
@@ -4,7 +4,7 @@ Add a DeployTarget to lagoon
 
 ### Synopsis
 
-Add a DeployTarget (kubernetes or openshift) to lagoon, this requires admin level permissions
+Add a Deploytarget(Kubernetes) to lagoon, this requires admin level permissions
 
 ```
 lagoon add deploytarget [flags]

--- a/docs/commands/lagoon_add_project.md
+++ b/docs/commands/lagoon_add_project.md
@@ -17,12 +17,12 @@ lagoon add project [flags]
   -a, --auto-idle uint                          Auto idle setting of the project
   -b, --branches string                         Which branches should be deployed
       --build-image string                      Build Image for the project
+  -S, --deploytarget uint                       Reference to Deploytarget(Kubernetes) target this Project should be deployed to
+      --deploytarget-project-pattern string     Pattern of Deploytarget(Kubernetes) Project/Namespace that should be generated
   -L, --development-environments-limit uint     How many environments can be deployed at one time
   -g, --git-url string                          GitURL of the project
   -h, --help                                    help for project
   -j, --json string                             JSON string to patch
-  -S, --openshift uint                          Reference to OpenShift Object this Project should be deployed to
-  -o, --openshift-project-pattern string        Pattern of OpenShift Project/Namespace that should be generated
       --organization-id uint                    ID of the Organization to add the project to
   -O, --organization-name string                Name of the Organization to add the project to
       --owner                                   Add the user as an owner of the project

--- a/docs/commands/lagoon_delete_deploytarget.md
+++ b/docs/commands/lagoon_delete_deploytarget.md
@@ -4,7 +4,7 @@ Delete a DeployTarget from lagoon
 
 ### Synopsis
 
-Delete a DeployTarget (kubernetes or openshift) from lagoon, this requires admin level permissions
+Delete a Deploytarget(Kubernetes) from lagoon, this requires admin level permissions
 
 ```
 lagoon delete deploytarget [flags]

--- a/docs/commands/lagoon_deploy_branch.md
+++ b/docs/commands/lagoon_deploy_branch.md
@@ -16,10 +16,10 @@ lagoon deploy branch [flags]
 
 ```
   -b, --branch string          Branch name to deploy
-  -r, --branchRef string       Branch ref to deploy
+  -r, --branch-ref string      Branch ref to deploy
       --buildvar stringArray   Add one or more build variables to deployment (--buildvar KEY1=VALUE1 [--buildvar KEY2=VALUE2])
   -h, --help                   help for branch
-      --returnData             Returns the build name instead of success text
+      --returndata             Returns the build name instead of success text
 ```
 
 ### Options inherited from parent commands

--- a/docs/commands/lagoon_deploy_latest.md
+++ b/docs/commands/lagoon_deploy_latest.md
@@ -16,7 +16,7 @@ lagoon deploy latest [flags]
 ```
       --buildvar stringArray   Add one or more build variables to deployment (--buildvar KEY1=VALUE1 [--buildvar KEY2=VALUE2])
   -h, --help                   help for latest
-      --returnData             Returns the build name instead of success text
+      --returndata             Returns the build name instead of success text
 ```
 
 ### Options inherited from parent commands

--- a/docs/commands/lagoon_deploy_promote.md
+++ b/docs/commands/lagoon_deploy_promote.md
@@ -16,7 +16,7 @@ lagoon deploy promote [flags]
       --buildvar stringArray   Add one or more build variables to deployment (--buildvar KEY1=VALUE1 [--buildvar KEY2=VALUE2])
   -d, --destination string     Destination environment name to create
   -h, --help                   help for promote
-      --returnData             Returns the build name instead of success text
+      --returndata             Returns the build name instead of success text
   -s, --source string          Source environment name to use as the base to deploy from
 ```
 

--- a/docs/commands/lagoon_deploy_pullrequest.md
+++ b/docs/commands/lagoon_deploy_pullrequest.md
@@ -14,15 +14,15 @@ lagoon deploy pullrequest [flags]
 ### Options
 
 ```
-  -N, --baseBranchName string   Pullrequest base branch name
-  -R, --baseBranchRef string    Pullrequest base branch reference hash
-      --buildvar stringArray    Add one or more build variables to deployment (--buildvar KEY1=VALUE1 [--buildvar KEY2=VALUE2])
-  -H, --headBranchName string   Pullrequest head branch name
-  -M, --headBranchRef string    Pullrequest head branch reference hash
-  -h, --help                    help for pullrequest
-  -n, --number uint             Pullrequest number
-      --returnData              Returns the build name instead of success text
-  -t, --title string            Pullrequest title
+  -N, --base-branch-name string   Pullrequest base branch name
+  -R, --base-branch-ref string    Pullrequest base branch reference hash
+      --buildvar stringArray      Add one or more build variables to deployment (--buildvar KEY1=VALUE1 [--buildvar KEY2=VALUE2])
+  -H, --head-branch-name string   Pullrequest head branch name
+  -M, --head-branch-ref string    Pullrequest head branch reference hash
+  -h, --help                      help for pullrequest
+  -n, --number uint               Pullrequest number
+      --returndata                Returns the build name instead of success text
+  -t, --title string              Pullrequest title
 ```
 
 ### Options inherited from parent commands

--- a/docs/commands/lagoon_list_deploytargets.md
+++ b/docs/commands/lagoon_list_deploytargets.md
@@ -4,7 +4,7 @@ List all DeployTargets in Lagoon
 
 ### Synopsis
 
-List all DeployTargets (kubernetes or openshift) in lagoon, this requires admin level permissions
+List all Deploytargets(Kubernetes) in lagoon, this requires admin level permissions
 
 ```
 lagoon list deploytargets [flags]

--- a/docs/commands/lagoon_list_group-users.md
+++ b/docs/commands/lagoon_list_group-users.md
@@ -6,7 +6,7 @@ List all users in groups
 
 List all users in groups in lagoon, this only shows users that are in groups.
 If no group name is provided, all groups are queried.
-Without a group name, this query may time out in large Lagoon installs.
+Without a group name, this query may time out in large Lagoon instalschema.
 
 ```
 lagoon list group-users [flags]

--- a/docs/commands/lagoon_logs.md
+++ b/docs/commands/lagoon_logs.md
@@ -1,24 +1,19 @@
-## lagoon import
+## lagoon logs
 
-Import a config from a yaml file
-
-### Synopsis
-
-Import a config from a yaml file.
-By default this command will exit on encountering an error (such as an existing object).
-You can get it to continue anyway with --keep-going. To disable any prompts, use --force.
+Display logs for a service of an environment and project
 
 ```
-lagoon import [flags]
+lagoon logs [flags]
 ```
 
 ### Options
 
 ```
-      --deploytarget-id uint   ID of the deploytarget to target for import
-  -h, --help                   help for import
-  -I, --import-file string     path to the file to import
-      --keep-going             on error, just log and continue instead of aborting
+  -c, --container string   specify a specific container name
+  -f, --follow             continue outputting new lines as they are logged
+  -h, --help               help for logs
+  -n, --lines uint         the number of lines to return for each container (default 32)
+  -s, --service string     specify a specific service name
 ```
 
 ### Options inherited from parent commands

--- a/docs/commands/lagoon_update_deploytarget.md
+++ b/docs/commands/lagoon_update_deploytarget.md
@@ -4,7 +4,7 @@ Update a DeployTarget in lagoon
 
 ### Synopsis
 
-Update a DeployTarget (kubernetes or openshift) in lagoon, this requires admin level permissions
+Update a Deploytarget(Kubernetes) in lagoon, this requires admin level permissions
 
 ```
 lagoon update deploytarget [flags]

--- a/docs/commands/lagoon_update_environment.md
+++ b/docs/commands/lagoon_update_environment.md
@@ -14,7 +14,7 @@ lagoon update environment [flags]
       --deploy-head-ref string    Updates the deploy head ref for the selected environment
       --deploy-title string       Updates the deploy title for the selected environment
       --deploy-type string        Update the deploy type - branch | pullrequest | promote
-  -d, --deploytarget uint         Reference to OpenShift Object this Environment should be deployed to
+  -d, --deploytarget uint         Reference to Deploytarget(Kubernetes) this Environment should be deployed to
       --environment-type string   Update the environment type - production | development
   -h, --help                      help for environment
       --namespace string          Update the namespace for the selected environment

--- a/docs/commands/lagoon_update_project.md
+++ b/docs/commands/lagoon_update_project.md
@@ -14,6 +14,8 @@ lagoon update project [flags]
   -b, --branches string                         Which branches should be deployed
       --build-image string                      Build Image for the project. Set to 'null' to remove the build image
       --deployments-disabled uint               Admin only flag for disabling deployments on a project, 1 to disable deployments, 0 to enable
+  -S, --deploytarget uint                       Reference to Deploytarget(Kubernetes) this Project should be deployed to
+  -o, --deploytarget-project-pattern string     Pattern of Deploytarget(Kubernetes) Project/Namespace that should be generated
       --development-build-priority uint         Set the priority of the development build
   -L, --development-environments-limit uint     How many environments can be deployed at one time
       --facts-ui uint                           Enables the Lagoon insights Facts tab in the UI. Set to 1 to enable, 0 to disable
@@ -21,8 +23,6 @@ lagoon update project [flags]
   -h, --help                                    help for project
   -j, --json string                             JSON string to patch
   -N, --name string                             Change the name of the project by specifying a new name (careful!)
-  -S, --openshift uint                          Reference to OpenShift Object this Project should be deployed to
-  -o, --openshift-project-pattern string        Pattern of OpenShift Project/Namespace that should be generated
   -I, --private-key string                      Private key to use for the project
       --problems-ui uint                        Enables the Lagoon insights Problems tab in the UI. Set to 1 to enable, 0 to disable
       --production-build-priority uint          Set the priority of the production build


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

Just fixing up more flags. 

This also changes all the `openshift` flags and references to `deploytarget` and mentions kubernetes only too.

This is a breaking change, but in combination with all the other breaking changes that have been merged, we can call this out in the release notes that the release is considerably breaky
