### PR TITLE
feat: support for organization admins and changes to use role flag

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -1055,14 +1055,7 @@ var ListOrganizationUsersCmd = &cobra.Command{
 			lagoonCLIConfig.Lagoons[current].Version,
 			&token,
 			debug)
-		organization, err := lagoon.GetOrganizationByName(context.Background(), organizationName, lc)
-		if err != nil {
-			return err
-		}
-		if organization.Name == "" {
-			return fmt.Errorf("error querying organization by name")
-		}
-		users, err := lagoon.UsersByOrganization(context.TODO(), organization.ID, lc)
+		users, err := lagoon.UsersByOrganizationName(context.TODO(), organizationName, lc)
 		if err != nil {
 			return err
 		}
@@ -1070,16 +1063,71 @@ var ListOrganizationUsersCmd = &cobra.Command{
 		data := []output.Data{}
 		for _, user := range *users {
 			data = append(data, []string{
-				returnNonEmptyString(user.ID),
+				returnNonEmptyString(user.ID.String()),
 				returnNonEmptyString(user.Email),
 				returnNonEmptyString(user.FirstName),
 				returnNonEmptyString(user.LastName),
 				returnNonEmptyString(user.Comment),
-				returnNonEmptyString(fmt.Sprintf("%v", user.Owner)),
 			})
 		}
 		dataMain := output.Table{
-			Header: []string{"ID", "Email", "First Name", "LastName", "Comment", "Owner"},
+			Header: []string{"ID", "Email", "First Name", "LastName", "Comment"},
+			Data:   data,
+		}
+		output.RenderOutput(dataMain, outputOptions)
+		return nil
+	},
+}
+
+var ListOrganizationAdminsCmd = &cobra.Command{
+	Use:     "organization-admins",
+	Aliases: []string{"org-a"},
+	Short:   "List admins in an organization",
+	PreRunE: func(_ *cobra.Command, _ []string) error {
+		return validateTokenE(cmdLagoon)
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		debug, err := cmd.Flags().GetBool("debug")
+		if err != nil {
+			return err
+		}
+		organizationName, err := cmd.Flags().GetString("organization-name")
+		if err != nil {
+			return err
+		}
+		if err := requiredInputCheck("Organization name", organizationName); err != nil {
+			return err
+		}
+
+		current := lagoonCLIConfig.Current
+		token := lagoonCLIConfig.Lagoons[current].Token
+		lc := lclient.New(
+			lagoonCLIConfig.Lagoons[current].GraphQL,
+			lagoonCLIVersion,
+			lagoonCLIConfig.Lagoons[current].Version,
+			&token,
+			debug)
+		users, err := lagoon.ListOrganizationAdminsByName(context.TODO(), organizationName, lc)
+		if err != nil {
+			return err
+		}
+
+		data := []output.Data{}
+		for _, user := range *users {
+			role := "viewer"
+			if user.Owner {
+				role = "owner"
+			}
+			data = append(data, []string{
+				returnNonEmptyString(user.ID.String()),
+				returnNonEmptyString(user.Email),
+				returnNonEmptyString(user.FirstName),
+				returnNonEmptyString(user.LastName),
+				returnNonEmptyString(role),
+			})
+		}
+		dataMain := output.Table{
+			Header: []string{"ID", "Email", "First Name", "LastName", "OrganizationRole"},
 			Data:   data,
 		}
 		output.RenderOutput(dataMain, outputOptions)
@@ -1155,6 +1203,7 @@ func init() {
 	listCmd.AddCommand(listUsersGroupsCmd)
 	listCmd.AddCommand(listOrganizationProjectsCmd)
 	listCmd.AddCommand(ListOrganizationUsersCmd)
+	listCmd.AddCommand(ListOrganizationAdminsCmd)
 	listCmd.AddCommand(listOrganizationGroupsCmd)
 	listCmd.AddCommand(listOrganizationDeployTargetsCmd)
 	listCmd.AddCommand(listOrganizationsCmd)
@@ -1167,6 +1216,7 @@ func init() {
 	listVariablesCmd.Flags().BoolP("reveal", "", false, "Reveal the variable values")
 	listOrganizationProjectsCmd.Flags().StringP("organization-name", "O", "", "Name of the organization to list associated projects for")
 	ListOrganizationUsersCmd.Flags().StringP("organization-name", "O", "", "Name of the organization to list associated users for")
+	ListOrganizationAdminsCmd.Flags().StringP("organization-name", "O", "", "Name of the organization to list associated users for")
 	listOrganizationGroupsCmd.Flags().StringP("organization-name", "O", "", "Name of the organization to list associated groups for")
 	listOrganizationDeployTargetsCmd.Flags().StringP("organization-name", "O", "", "Name of the organization to list associated deploy targets for")
 	listOrganizationDeployTargetsCmd.Flags().Uint("id", 0, "ID of the organization to list associated deploy targets for")

--- a/docs/commands/lagoon_delete_organization-administrator.md
+++ b/docs/commands/lagoon_delete_organization-administrator.md
@@ -12,7 +12,6 @@ lagoon delete organization-administrator [flags]
   -E, --email string               Email address of the user
   -h, --help                       help for organization-administrator
   -O, --organization-name string   Name of the organization
-      --owner                      Set the user as an administrator of the organization
 ```
 
 ### Options inherited from parent commands

--- a/docs/commands/lagoon_list.md
+++ b/docs/commands/lagoon_list.md
@@ -43,6 +43,7 @@ List projects, environments, deployments, variables or notifications
 * [lagoon list groups](lagoon_list_groups.md)	 - List groups you have access to (alias: g)
 * [lagoon list invokable-tasks](lagoon_list_invokable-tasks.md)	 - Print a list of invokable tasks
 * [lagoon list notification](lagoon_list_notification.md)	 - List all notifications or notifications on projects
+* [lagoon list organization-admins](lagoon_list_organization-admins.md)	 - List admins in an organization
 * [lagoon list organization-deploytargets](lagoon_list_organization-deploytargets.md)	 - List deploy targets in an organization
 * [lagoon list organization-groups](lagoon_list_organization-groups.md)	 - List groups in an organization
 * [lagoon list organization-projects](lagoon_list_organization-projects.md)	 - List projects in an organization

--- a/docs/commands/lagoon_list_organization-admins.md
+++ b/docs/commands/lagoon_list_organization-admins.md
@@ -1,22 +1,16 @@
-## lagoon add organization-administrator
+## lagoon list organization-admins
 
-Add an administrator to an Organization
-
-### Synopsis
-
-Add an administrator to an Organization. If the role flag is not provided users will be added as viewers
+List admins in an organization
 
 ```
-lagoon add organization-administrator [flags]
+lagoon list organization-admins [flags]
 ```
 
 ### Options
 
 ```
-  -E, --email string               Email address of the user
-  -h, --help                       help for organization-administrator
-  -O, --organization-name string   Name of the organization
-  -R, --role string                Role in the organization [owner, viewer]
+  -h, --help                       help for organization-admins
+  -O, --organization-name string   Name of the organization to list associated users for
 ```
 
 ### Options inherited from parent commands
@@ -41,5 +35,5 @@ lagoon add organization-administrator [flags]
 
 ### SEE ALSO
 
-* [lagoon add](lagoon_add.md)	 - Add a project, or add notifications and variables to projects or environments
+* [lagoon list](lagoon_list.md)	 - List projects, environments, deployments, variables or notifications
 

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.2
-	github.com/uselagoon/machinery v0.0.22
+	github.com/uselagoon/machinery v0.0.23
 	golang.org/x/crypto v0.21.0
 	golang.org/x/term v0.18.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -66,8 +66,8 @@ github.com/stretchr/testify v1.7.4/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/uselagoon/machinery v0.0.22 h1:4FVJRLS8he2NAZYMIJXQqVb25jQ03tF8dNhQbrBMX3g=
-github.com/uselagoon/machinery v0.0.22/go.mod h1:NbgtEofjK2XY0iUpk9aMYazIo+W/NI56+UF72jv8zVY=
+github.com/uselagoon/machinery v0.0.23 h1:8fRoVo3/dAByFQQH7Po35vEjFmtT4MmE326EuCkSvFc=
+github.com/uselagoon/machinery v0.0.23/go.mod h1:NbgtEofjK2XY0iUpk9aMYazIo+W/NI56+UF72jv8zVY=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

This adds a new command to list just the organization administrators and their role, this is `list organization-admins`

It removes the `owner` column from the `list organization-users` query too, as this doesn't work properly.