### PR TITLE
Change: Updates the output for Render functions

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -129,10 +129,11 @@ var configLagoonsCmd = &cobra.Command{
 			tableHeader = append(tableHeader, "Kibana-URL")
 		}
 		tableHeader = append(tableHeader, "SSH-Key")
-		output.RenderOutput(output.Table{
+		r := output.RenderOutput(output.Table{
 			Header: tableHeader,
 			Data:   data,
 		}, outputOptions)
+		fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		return nil
 	},
 }
@@ -176,7 +177,7 @@ var configAddCmd = &cobra.Command{
 			if err := writeLagoonConfig(&lagoonCLIConfig, filepath.Join(configFilePath, configName+configExtension)); err != nil {
 				return fmt.Errorf("couldn't write config: %v", err)
 			}
-			output.RenderOutput(output.Table{
+			r := output.RenderOutput(output.Table{
 				Header: []string{
 					"Name",
 					"GraphQL",
@@ -198,6 +199,7 @@ var configAddCmd = &cobra.Command{
 					},
 				},
 			}, outputOptions)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		} else {
 			return fmt.Errorf("must have Hostname, Port, and GraphQL endpoint")
 		}

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -82,7 +82,8 @@ var configDefaultCmd = &cobra.Command{
 				"default-lagoon": lagoonConfig.Lagoon,
 			},
 		}
-		output.RenderResult(resultData, outputOptions)
+		r := output.RenderResult(resultData, outputOptions)
+		fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 	},
 }
 

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"github.com/uselagoon/lagoon-cli/pkg/output"
 	"strconv"
 
 	lclient "github.com/uselagoon/machinery/api/lagoon/client"
@@ -80,7 +81,9 @@ use 'lagoon deploy latest' instead`,
 			if err != nil {
 				return err
 			}
-			fmt.Println(result.DeployEnvironmentBranch)
+			resultData := output.Result{Result: result.DeployEnvironmentBranch}
+			r := output.RenderResult(resultData, outputOptions)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		}
 		return nil
 	},
@@ -143,7 +146,9 @@ var deployPromoteCmd = &cobra.Command{
 			if err != nil {
 				return err
 			}
-			fmt.Println(result.DeployEnvironmentPromote)
+			resultData := output.Result{Result: result.DeployEnvironmentPromote}
+			r := output.RenderResult(resultData, outputOptions)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		}
 		return nil
 	},
@@ -204,7 +209,9 @@ This environment should already exist in lagoon. It is analogous with the 'Deplo
 			if err != nil {
 				return err
 			}
-			fmt.Println(result.DeployEnvironmentLatest)
+			resultData := output.Result{Result: result.DeployEnvironmentLatest}
+			r := output.RenderResult(resultData, outputOptions)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		}
 		return nil
 	},
@@ -291,7 +298,9 @@ This pullrequest may not already exist as an environment in lagoon.`,
 			if err != nil {
 				return err
 			}
-			fmt.Println(result.DeployEnvironmentPullrequest)
+			resultData := output.Result{Result: result.DeployEnvironmentPullrequest}
+			r := output.RenderResult(resultData, outputOptions)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		}
 		return nil
 	},

--- a/cmd/deploytarget.go
+++ b/cmd/deploytarget.go
@@ -120,7 +120,7 @@ var addDeployTargetCmd = &cobra.Command{
 				returnNonEmptyString(fmt.Sprintf("%v", addDeployTargetResponse.Created)),
 				returnNonEmptyString(fmt.Sprintf("%v", addDeployTargetResponse.MonitoringConfig)),
 			})
-			output.RenderOutput(output.Table{
+			r := output.RenderOutput(output.Table{
 				Header: []string{
 					"ID",
 					"Name",
@@ -138,6 +138,7 @@ var addDeployTargetCmd = &cobra.Command{
 				},
 				Data: data,
 			}, outputOptions)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		}
 		return nil
 	},
@@ -252,7 +253,7 @@ var updateDeployTargetCmd = &cobra.Command{
 				returnNonEmptyString(fmt.Sprintf("%v", updateDeployTargetResponse.Created)),
 				returnNonEmptyString(fmt.Sprintf("%v", updateDeployTargetResponse.MonitoringConfig)),
 			})
-			output.RenderOutput(output.Table{
+			r := output.RenderOutput(output.Table{
 				Header: []string{
 					"ID",
 					"Name",
@@ -270,6 +271,7 @@ var updateDeployTargetCmd = &cobra.Command{
 				},
 				Data: data,
 			}, outputOptions)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		}
 		return nil
 	},
@@ -319,7 +321,8 @@ var deleteDeployTargetCmd = &cobra.Command{
 			resultData := output.Result{
 				Result: deleteDeployTargetResponse.DeleteDeployTarget,
 			}
-			output.RenderResult(resultData, outputOptions)
+			r := output.RenderResult(resultData, outputOptions)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		}
 		return nil
 	},
@@ -383,7 +386,8 @@ var addDeployTargetToOrganizationCmd = &cobra.Command{
 				"Organization Name": deployTargetResponse.Name,
 			},
 		}
-		output.RenderResult(resultData, outputOptions)
+		r := output.RenderResult(resultData, outputOptions)
+		fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		return nil
 	},
 }
@@ -447,7 +451,8 @@ var removeDeployTargetFromOrganizationCmd = &cobra.Command{
 					"Organization Name": organizationName,
 				},
 			}
-			output.RenderResult(resultData, outputOptions)
+			r := output.RenderResult(resultData, outputOptions)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		}
 		return nil
 	},

--- a/cmd/deploytargetconfig.go
+++ b/cmd/deploytargetconfig.go
@@ -249,7 +249,11 @@ var deleteDeployTargetConfigCmd = &cobra.Command{
 			if err != nil {
 				return err
 			}
-			fmt.Println(result.DeleteDeployTargetConfig)
+			resultData := output.Result{
+				Result: result.DeleteDeployTargetConfig,
+			}
+			r := output.RenderResult(resultData, outputOptions)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		}
 		return nil
 	},

--- a/cmd/deploytargetconfig.go
+++ b/cmd/deploytargetconfig.go
@@ -90,7 +90,7 @@ var addDeployTargetConfigCmd = &cobra.Command{
 				returnNonEmptyString(fmt.Sprintf("%v", deployTargetConfig.DeployTarget.CloudProvider)),
 				returnNonEmptyString(fmt.Sprintf("%v", deployTargetConfig.DeployTarget.CloudRegion)),
 			})
-			output.RenderOutput(output.Table{
+			r := output.RenderOutput(output.Table{
 				Header: []string{
 					"ID",
 					"Weight",
@@ -103,6 +103,7 @@ var addDeployTargetConfigCmd = &cobra.Command{
 				},
 				Data: data,
 			}, outputOptions)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		}
 		return nil
 	},
@@ -184,7 +185,7 @@ var updateDeployTargetConfigCmd = &cobra.Command{
 				returnNonEmptyString(fmt.Sprintf("%v", deployTargetConfig.DeployTarget.CloudProvider)),
 				returnNonEmptyString(fmt.Sprintf("%v", deployTargetConfig.DeployTarget.CloudRegion)),
 			})
-			output.RenderOutput(output.Table{
+			r := output.RenderOutput(output.Table{
 				Header: []string{
 					"ID",
 					"Weight",
@@ -197,6 +198,7 @@ var updateDeployTargetConfigCmd = &cobra.Command{
 				},
 				Data: data,
 			}, outputOptions)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		}
 		return nil
 	},
@@ -306,7 +308,7 @@ var listDeployTargetConfigsCmd = &cobra.Command{
 				returnNonEmptyString(fmt.Sprintf("%v", deployTargetConfig.DeployTarget.CloudRegion)),
 			})
 		}
-		output.RenderOutput(output.Table{
+		r := output.RenderOutput(output.Table{
 			Header: []string{
 				"ID",
 				"Weight",
@@ -319,6 +321,7 @@ var listDeployTargetConfigsCmd = &cobra.Command{
 			},
 			Data: data,
 		}, outputOptions)
+		fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		return nil
 	},
 }

--- a/cmd/environment.go
+++ b/cmd/environment.go
@@ -293,7 +293,9 @@ This returns a direct URL to the backup, this is a signed download link with a l
 		for _, backup := range backupsResult.Backups {
 			if backup.BackupID == backupID {
 				if backup.Restore.RestoreLocation != "" {
-					fmt.Println(backup.Restore.RestoreLocation)
+					resultData := output.Result{Result: backup.Restore.RestoreLocation}
+					r := output.RenderResult(resultData, outputOptions)
+					fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 					return nil
 				}
 				status = backup.Restore.Status

--- a/cmd/environment.go
+++ b/cmd/environment.go
@@ -50,7 +50,8 @@ var deleteEnvCmd = &cobra.Command{
 			resultData := output.Result{
 				Result: environment.DeleteEnvironment,
 			}
-			output.RenderResult(resultData, outputOptions)
+			r := output.RenderResult(resultData, outputOptions)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		}
 		return nil
 	},
@@ -172,7 +173,8 @@ var updateEnvironmentCmd = &cobra.Command{
 				"Environment Name": result.Name,
 			},
 		}
-		output.RenderResult(resultData, outputOptions)
+		r := output.RenderResult(resultData, outputOptions)
+		fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		return nil
 	},
 }
@@ -233,7 +235,7 @@ var listBackupsCmd = &cobra.Command{
 				returnNonEmptyString(fmt.Sprintf("%v", backup.Restore.Status)),
 			})
 		}
-		output.RenderOutput(output.Table{
+		r := output.RenderOutput(output.Table{
 			Header: []string{
 				"BackupID",
 				"Source",
@@ -243,6 +245,7 @@ var listBackupsCmd = &cobra.Command{
 			},
 			Data: data,
 		}, outputOptions)
+		fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		return nil
 	},
 }

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -64,7 +64,8 @@ var getProjectCmd = &cobra.Command{
 
 		if project.Name == "" {
 			outputOptions.Error = fmt.Sprintf("No details for project '%s'\n", cmdProjectName)
-			output.RenderOutput(output.Table{Data: []output.Data{[]string{}}}, outputOptions)
+			r := output.RenderOutput(output.Table{Data: []output.Data{[]string{}}}, outputOptions)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 			return nil
 		}
 
@@ -126,7 +127,8 @@ var getProjectCmd = &cobra.Command{
 			Header: projHeader,
 			Data:   data,
 		}
-		output.RenderOutput(dataMain, outputOptions)
+		r := output.RenderOutput(dataMain, outputOptions)
+		fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		return nil
 	},
 }
@@ -177,7 +179,8 @@ This returns information about a deployment, the logs of this build can also be 
 					},
 				},
 			}
-			output.RenderOutput(dataMain, outputOptions)
+			r := output.RenderOutput(dataMain, outputOptions)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 			return nil
 		}
 		dataMain := output.Table{
@@ -202,7 +205,8 @@ This returns information about a deployment, the logs of this build can also be 
 				},
 			},
 		}
-		output.RenderOutput(dataMain, outputOptions)
+		r := output.RenderOutput(dataMain, outputOptions)
+		fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		return nil
 	},
 }
@@ -278,7 +282,8 @@ var getEnvironmentCmd = &cobra.Command{
 			Header: envHeader,
 			Data:   data,
 		}
-		output.RenderOutput(dataMain, outputOptions)
+		r := output.RenderOutput(dataMain, outputOptions)
+		fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		return nil
 	},
 }
@@ -328,14 +333,16 @@ var getProjectKeyCmd = &cobra.Command{
 
 		if len(dataMain.Data) == 0 {
 			outputOptions.Error = fmt.Sprintf("No project-key for project '%s'", cmdProjectName)
-			output.RenderOutput(output.Table{Data: []output.Data{[]string{}}}, outputOptions)
+			r := output.RenderOutput(output.Table{Data: []output.Data{[]string{}}}, outputOptions)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 			return nil
 		}
 
 		if projectKey.PrivateKey != "" {
 			dataMain.Header = append(dataMain.Header, "PrivateKey")
 		}
-		output.RenderOutput(dataMain, outputOptions)
+		r := output.RenderOutput(dataMain, outputOptions)
+		fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		return nil
 	},
 }
@@ -405,7 +412,8 @@ var getOrganizationCmd = &cobra.Command{
 			Data:   data,
 		}
 
-		output.RenderOutput(dataMain, outputOptions)
+		r := output.RenderOutput(dataMain, outputOptions)
+		fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		return nil
 	},
 }

--- a/cmd/groups.go
+++ b/cmd/groups.go
@@ -89,7 +89,8 @@ var addGroupCmd = &cobra.Command{
 		if organizationName != "" {
 			resultData.ResultData["Organization"] = organizationName
 		}
-		output.RenderResult(resultData, outputOptions)
+		r := output.RenderResult(resultData, outputOptions)
+		fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		return nil
 	},
 }
@@ -162,7 +163,8 @@ var addUserToGroupCmd = &cobra.Command{
 		resultData := output.Result{
 			Result: "success",
 		}
-		output.RenderResult(resultData, outputOptions)
+		r := output.RenderResult(resultData, outputOptions)
+		fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		return nil
 	},
 }
@@ -224,7 +226,8 @@ var addProjectToGroupCmd = &cobra.Command{
 		resultData := output.Result{
 			Result: "success",
 		}
-		output.RenderResult(resultData, outputOptions)
+		r := output.RenderResult(resultData, outputOptions)
+		fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		return nil
 	},
 }
@@ -280,7 +283,8 @@ var deleteUserFromGroupCmd = &cobra.Command{
 					"id": result.ID,
 				},
 			}
-			output.RenderResult(resultData, outputOptions)
+			r := output.RenderResult(resultData, outputOptions)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		}
 		return nil
 	},
@@ -345,7 +349,8 @@ var deleteProjectFromGroupCmd = &cobra.Command{
 			resultData := output.Result{
 				Result: "success",
 			}
-			output.RenderResult(resultData, outputOptions)
+			r := output.RenderResult(resultData, outputOptions)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		}
 		return nil
 	},
@@ -384,7 +389,8 @@ var deleteGroupCmd = &cobra.Command{
 			resultData := output.Result{
 				Result: "success",
 			}
-			output.RenderResult(resultData, outputOptions)
+			r := output.RenderResult(resultData, outputOptions)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		}
 		return nil
 	},

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -1104,7 +1104,8 @@ var ListOrganizationUsersCmd = &cobra.Command{
 			Header: []string{"ID", "Email", "First Name", "LastName", "Comment"},
 			Data:   data,
 		}
-		output.RenderOutput(dataMain, outputOptions)
+		r := output.RenderOutput(dataMain, outputOptions)
+		fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		return nil
 	},
 }

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -82,8 +82,8 @@ var listProjectsCmd = &cobra.Command{
 			Header: []string{"ID", "ProjectName", "GitUrl", "ProductionEnvironment", "ProductionRoute", "DevEnvironments"},
 			Data:   data,
 		}
-
-		output.RenderOutput(dataMain, outputOptions)
+		r := output.RenderOutput(dataMain, outputOptions)
+		fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		return nil
 	},
 }
@@ -132,7 +132,7 @@ var listDeployTargetsCmd = &cobra.Command{
 			})
 		}
 		outputOptions.MultiLine = true
-		output.RenderOutput(output.Table{
+		r := output.RenderOutput(output.Table{
 			Header: []string{
 				"ID",
 				"Name",
@@ -150,6 +150,7 @@ var listDeployTargetsCmd = &cobra.Command{
 			},
 			Data: data,
 		}, outputOptions)
+		fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		return nil
 	},
 }
@@ -194,7 +195,8 @@ var listGroupsCmd = &cobra.Command{
 			Header: []string{"ID", "Name"},
 			Data:   data,
 		}
-		output.RenderOutput(dataMain, outputOptions)
+		r := output.RenderOutput(dataMain, outputOptions)
+		fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		return nil
 	},
 }
@@ -268,7 +270,8 @@ var listGroupProjectsCmd = &cobra.Command{
 			} else {
 				outputOptions.Error = "There are no projects in any groups\n"
 			}
-			output.RenderOutput(output.Table{Data: []output.Data{[]string{}}}, outputOptions)
+			r := output.RenderOutput(output.Table{Data: []output.Data{[]string{}}}, outputOptions)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 			return nil
 		}
 
@@ -279,7 +282,8 @@ var listGroupProjectsCmd = &cobra.Command{
 		if listAllProjects {
 			dataMain.Header = append(dataMain.Header, "GroupName")
 		}
-		output.RenderOutput(dataMain, outputOptions)
+		r := output.RenderOutput(dataMain, outputOptions)
+		fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		return nil
 	},
 }
@@ -315,7 +319,8 @@ var listEnvironmentsCmd = &cobra.Command{
 
 		if len(*environments) == 0 {
 			outputOptions.Error = fmt.Sprintf("No environments found for project '%s'\n", cmdProjectName)
-			output.RenderOutput(output.Table{Data: []output.Data{[]string{}}}, outputOptions)
+			r := output.RenderOutput(output.Table{Data: []output.Data{[]string{}}}, outputOptions)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 			return nil
 		}
 
@@ -339,7 +344,8 @@ var listEnvironmentsCmd = &cobra.Command{
 			Header: []string{"ID", "Name", "DeployType", "EnvironmentType", "Namespace", "Route", "DeployTarget"},
 			Data:   data,
 		}
-		output.RenderOutput(dataMain, outputOptions)
+		r := output.RenderOutput(dataMain, outputOptions)
+		fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		return nil
 	},
 }
@@ -414,13 +420,15 @@ var listVariablesCmd = &cobra.Command{
 			} else {
 				outputOptions.Error = fmt.Sprintf("There are no variables for project '%s'\n", cmdProjectName)
 			}
-			output.RenderOutput(output.Table{Data: []output.Data{[]string{}}}, outputOptions)
+			r := output.RenderOutput(output.Table{Data: []output.Data{[]string{}}}, outputOptions)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 			return nil
 		}
-		output.RenderOutput(output.Table{
+		r := output.RenderOutput(output.Table{
 			Header: header,
 			Data:   data,
 		}, outputOptions)
+		fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		return nil
 	},
 }
@@ -475,14 +483,16 @@ var listDeploymentsCmd = &cobra.Command{
 
 		if len(data) == 0 {
 			outputOptions.Error = fmt.Sprintf("There are no deployments for environment '%s' in project '%s'\n", cmdProjectEnvironment, cmdProjectName)
-			output.RenderOutput(output.Table{Data: []output.Data{[]string{}}}, outputOptions)
+			r := output.RenderOutput(output.Table{Data: []output.Data{[]string{}}}, outputOptions)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 			return nil
 		}
 		dataMain := output.Table{
 			Header: []string{"ID", "RemoteID", "Name", "Status", "Created", "Started", "Completed"},
 			Data:   data,
 		}
-		output.RenderOutput(dataMain, outputOptions)
+		r := output.RenderOutput(dataMain, outputOptions)
+		fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		return nil
 	},
 }
@@ -538,14 +548,16 @@ var listTasksCmd = &cobra.Command{
 
 		if len(data) == 0 {
 			outputOptions.Error = fmt.Sprintf("There are no tasks for environment '%s' in project '%s'\n", cmdProjectEnvironment, cmdProjectName)
-			output.RenderOutput(output.Table{Data: []output.Data{[]string{}}}, outputOptions)
+			r := output.RenderOutput(output.Table{Data: []output.Data{[]string{}}}, outputOptions)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 			return nil
 		}
 		dataMain := output.Table{
 			Header: []string{"ID", "RemoteID", "Name", "Status", "Created", "Started", "Completed", "Service"},
 			Data:   data,
 		}
-		output.RenderOutput(dataMain, outputOptions)
+		r := output.RenderOutput(dataMain, outputOptions)
+		fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		return nil
 	},
 }
@@ -613,7 +625,8 @@ Without a group name, this query may time out in large Lagoon instalschema.`,
 			Header: []string{"ID", "GroupName", "Email", "Role"},
 			Data:   data,
 		}
-		output.RenderOutput(dataMain, outputOptions)
+		r := output.RenderOutput(dataMain, outputOptions)
+		fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		return nil
 	},
 }
@@ -664,7 +677,8 @@ This query can take a long time to run if there are a lot of users.`,
 			Header: []string{"ID", "Email", "FirstName", "LastName", "Comment"},
 			Data:   data,
 		}
-		output.RenderOutput(dataMain, outputOptions)
+		r := output.RenderOutput(dataMain, outputOptions)
+		fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		return nil
 	},
 }
@@ -714,7 +728,8 @@ var listUsersGroupsCmd = &cobra.Command{
 			Header: []string{"ID", "Email", "GroupName", "GroupRole"},
 			Data:   data,
 		}
-		output.RenderOutput(dataMain, outputOptions)
+		r := output.RenderOutput(dataMain, outputOptions)
+		fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		return nil
 	},
 }
@@ -764,14 +779,16 @@ var listInvokableTasks = &cobra.Command{
 
 		if len(data) == 0 {
 			outputOptions.Error = "There are no user defined tasks for this environment\n"
-			output.RenderOutput(output.Table{Data: []output.Data{[]string{}}}, outputOptions)
+			r := output.RenderOutput(output.Table{Data: []output.Data{[]string{}}}, outputOptions)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 			return nil
 		}
 		dataMain := output.Table{
 			Header: []string{"Task Name", "Description"},
 			Data:   data,
 		}
-		output.RenderOutput(dataMain, outputOptions)
+		r := output.RenderOutput(dataMain, outputOptions)
+		fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		return nil
 	},
 }
@@ -816,7 +833,8 @@ var listProjectGroupsCmd = &cobra.Command{
 
 		if len(projectGroups.Groups) == 0 {
 			outputOptions.Error = fmt.Sprintf("There are no groups for project '%s'\n", cmdProjectName)
-			output.RenderOutput(output.Table{Data: []output.Data{[]string{}}}, outputOptions)
+			r := output.RenderOutput(output.Table{Data: []output.Data{[]string{}}}, outputOptions)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 			return nil
 		}
 
@@ -836,7 +854,8 @@ var listProjectGroupsCmd = &cobra.Command{
 			Header: []string{"Group ID", "Group Name", "Organization"},
 			Data:   data,
 		}
-		output.RenderOutput(dataMain, outputOptions)
+		r := output.RenderOutput(dataMain, outputOptions)
+		fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		return nil
 	},
 }
@@ -884,7 +903,8 @@ var listOrganizationProjectsCmd = &cobra.Command{
 
 		if len(*orgProjects) == 0 {
 			outputOptions.Error = fmt.Sprintf("No associated projects found for organization '%s'\n", organizationName)
-			output.RenderOutput(output.Table{Data: []output.Data{[]string{}}}, outputOptions)
+			r := output.RenderOutput(output.Table{Data: []output.Data{[]string{}}}, outputOptions)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 			return nil
 		}
 
@@ -900,7 +920,8 @@ var listOrganizationProjectsCmd = &cobra.Command{
 			Header: []string{"ID", "Name", "Group Count"},
 			Data:   data,
 		}
-		output.RenderOutput(dataMain, outputOptions)
+		r := output.RenderOutput(dataMain, outputOptions)
+		fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		return nil
 	},
 }
@@ -947,7 +968,8 @@ var listOrganizationGroupsCmd = &cobra.Command{
 		}
 		if len(*orgGroups) == 0 {
 			outputOptions.Error = fmt.Sprintf("No associated groups found for organization '%s'\n", organizationName)
-			output.RenderOutput(output.Table{Data: []output.Data{[]string{}}}, outputOptions)
+			r := output.RenderOutput(output.Table{Data: []output.Data{[]string{}}}, outputOptions)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 			return nil
 		}
 
@@ -964,7 +986,8 @@ var listOrganizationGroupsCmd = &cobra.Command{
 			Header: []string{"ID", "Name", "Type", "Member Count"},
 			Data:   data,
 		}
-		output.RenderOutput(dataMain, outputOptions)
+		r := output.RenderOutput(dataMain, outputOptions)
+		fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		return nil
 	},
 }
@@ -1007,7 +1030,8 @@ var listOrganizationDeployTargetsCmd = &cobra.Command{
 		}
 		if len(*deployTargets) == 0 {
 			outputOptions.Error = fmt.Sprintf("No associated deploy targets found for organization '%s'\n", organizationName)
-			output.RenderOutput(output.Table{Data: []output.Data{[]string{}}}, outputOptions)
+			r := output.RenderOutput(output.Table{Data: []output.Data{[]string{}}}, outputOptions)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 			return nil
 		}
 
@@ -1027,7 +1051,8 @@ var listOrganizationDeployTargetsCmd = &cobra.Command{
 			Header: []string{"ID", "Name", "Router Pattern", "Cloud Region", "Cloud Provider", "SSH Host", "SSH Port"},
 			Data:   data,
 		}
-		output.RenderOutput(dataMain, outputOptions)
+		r := output.RenderOutput(dataMain, outputOptions)
+		fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		return nil
 	},
 }
@@ -1135,7 +1160,8 @@ var ListOrganizationAdminsCmd = &cobra.Command{
 			Header: []string{"ID", "Email", "First Name", "LastName", "OrganizationRole"},
 			Data:   data,
 		}
-		output.RenderOutput(dataMain, outputOptions)
+		r := output.RenderOutput(dataMain, outputOptions)
+		fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		return nil
 	},
 }
@@ -1184,7 +1210,8 @@ var listOrganizationsCmd = &cobra.Command{
 			Header: []string{"ID", "Name", "Description", "Project Quota", "Group Quota", "Notification Quota", "Environment Quota", "Route Quota"},
 			Data:   data,
 		}
-		output.RenderOutput(dataMain, outputOptions)
+		r := output.RenderOutput(dataMain, outputOptions)
+		fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		return nil
 	},
 }

--- a/cmd/notificationsemail.go
+++ b/cmd/notificationsemail.go
@@ -78,7 +78,7 @@ It does not configure a project to send notifications to email though, you need 
 				notificationData = append(notificationData, "-")
 			}
 			data = append(data, notificationData)
-			output.RenderOutput(output.Table{
+			r := output.RenderOutput(output.Table{
 				Header: []string{
 					"ID",
 					"Name",
@@ -87,6 +87,7 @@ It does not configure a project to send notifications to email though, you need 
 				},
 				Data: data,
 			}, outputOptions)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		}
 		return nil
 	},
@@ -135,7 +136,8 @@ This command is used to add an existing email notification in Lagoon to a projec
 			resultData := output.Result{
 				Result: "success",
 			}
-			output.RenderResult(resultData, outputOptions)
+			r := output.RenderResult(resultData, outputOptions)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		}
 		return nil
 	},
@@ -185,13 +187,14 @@ var listProjectEmailsCmd = &cobra.Command{
 				})
 			}
 		}
-		output.RenderOutput(output.Table{
+		r := output.RenderOutput(output.Table{
 			Header: []string{
 				"Name",
 				"EmailAddress",
 			},
 			Data: data,
 		}, outputOptions)
+		fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		return nil
 	},
 }
@@ -233,7 +236,7 @@ var listAllEmailsCmd = &cobra.Command{
 				}
 			}
 		}
-		output.RenderOutput(output.Table{
+		r := output.RenderOutput(output.Table{
 			Header: []string{
 				"Project",
 				"Name",
@@ -241,6 +244,7 @@ var listAllEmailsCmd = &cobra.Command{
 			},
 			Data: data,
 		}, outputOptions)
+		fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		return nil
 	},
 }
@@ -285,7 +289,8 @@ var deleteProjectEmailNotificationCmd = &cobra.Command{
 			resultData := output.Result{
 				Result: "success",
 			}
-			output.RenderResult(resultData, outputOptions)
+			r := output.RenderResult(resultData, outputOptions)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		}
 		return nil
 	},
@@ -326,7 +331,8 @@ var deleteEmailNotificationCmd = &cobra.Command{
 			resultData := output.Result{
 				Result: result.DeleteNotification,
 			}
-			output.RenderResult(resultData, outputOptions)
+			r := output.RenderResult(resultData, outputOptions)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		}
 		return nil
 	},
@@ -392,7 +398,7 @@ var updateEmailNotificationCmd = &cobra.Command{
 					returnNonEmptyString(fmt.Sprintf("%v", result.EmailAddress)),
 				},
 			}
-			output.RenderOutput(output.Table{
+			r := output.RenderOutput(output.Table{
 				Header: []string{
 					"ID",
 					"Name",
@@ -400,6 +406,7 @@ var updateEmailNotificationCmd = &cobra.Command{
 				},
 				Data: data,
 			}, outputOptions)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		}
 		return nil
 	},

--- a/cmd/notificationsrocketchat.go
+++ b/cmd/notificationsrocketchat.go
@@ -85,7 +85,7 @@ It does not configure a project to send notifications to RocketChat though, you 
 				notificationData = append(notificationData, "-")
 			}
 			data = append(data, notificationData)
-			output.RenderOutput(output.Table{
+			r := output.RenderOutput(output.Table{
 				Header: []string{
 					"ID",
 					"Name",
@@ -95,6 +95,7 @@ It does not configure a project to send notifications to RocketChat though, you 
 				},
 				Data: data,
 			}, outputOptions)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		}
 		return nil
 	},
@@ -144,7 +145,8 @@ This command is used to add an existing RocketChat notification in Lagoon to a p
 			resultData := output.Result{
 				Result: "success",
 			}
-			output.RenderResult(resultData, outputOptions)
+			r := output.RenderResult(resultData, outputOptions)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		}
 		return nil
 	},
@@ -195,7 +197,7 @@ var listProjectRocketChatsCmd = &cobra.Command{
 				})
 			}
 		}
-		output.RenderOutput(output.Table{
+		r := output.RenderOutput(output.Table{
 			Header: []string{
 				"Name",
 				"Webhook",
@@ -203,6 +205,7 @@ var listProjectRocketChatsCmd = &cobra.Command{
 			},
 			Data: data,
 		}, outputOptions)
+		fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		return nil
 	},
 }
@@ -245,7 +248,7 @@ var listAllRocketChatsCmd = &cobra.Command{
 				}
 			}
 		}
-		output.RenderOutput(output.Table{
+		r := output.RenderOutput(output.Table{
 			Header: []string{
 				"Project",
 				"Name",
@@ -254,6 +257,7 @@ var listAllRocketChatsCmd = &cobra.Command{
 			},
 			Data: data,
 		}, outputOptions)
+		fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		return nil
 	},
 }
@@ -298,7 +302,8 @@ var deleteProjectRocketChatNotificationCmd = &cobra.Command{
 			resultData := output.Result{
 				Result: "success",
 			}
-			output.RenderResult(resultData, outputOptions)
+			r := output.RenderResult(resultData, outputOptions)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		}
 		return nil
 	},
@@ -339,7 +344,8 @@ var deleteRocketChatNotificationCmd = &cobra.Command{
 			resultData := output.Result{
 				Result: result.DeleteNotification,
 			}
-			output.RenderResult(resultData, outputOptions)
+			r := output.RenderResult(resultData, outputOptions)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		}
 		return nil
 	},
@@ -411,7 +417,7 @@ var updateRocketChatNotificationCmd = &cobra.Command{
 					returnNonEmptyString(fmt.Sprintf("%v", result.Channel)),
 				},
 			}
-			output.RenderOutput(output.Table{
+			r := output.RenderOutput(output.Table{
 				Header: []string{
 					"ID",
 					"Name",
@@ -420,6 +426,7 @@ var updateRocketChatNotificationCmd = &cobra.Command{
 				},
 				Data: data,
 			}, outputOptions)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		}
 		return nil
 	},

--- a/cmd/notificationsslack.go
+++ b/cmd/notificationsslack.go
@@ -85,7 +85,7 @@ It does not configure a project to send notifications to Slack though, you need 
 				notificationData = append(notificationData, "-")
 			}
 			data = append(data, notificationData)
-			output.RenderOutput(output.Table{
+			r := output.RenderOutput(output.Table{
 				Header: []string{
 					"ID",
 					"Name",
@@ -95,6 +95,7 @@ It does not configure a project to send notifications to Slack though, you need 
 				},
 				Data: data,
 			}, outputOptions)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		}
 		return nil
 	},
@@ -142,7 +143,8 @@ This command is used to add an existing Slack notification in Lagoon to a projec
 			resultData := output.Result{
 				Result: "success",
 			}
-			output.RenderResult(resultData, outputOptions)
+			r := output.RenderResult(resultData, outputOptions)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		}
 		return nil
 	},
@@ -193,7 +195,7 @@ var listProjectSlacksCmd = &cobra.Command{
 				})
 			}
 		}
-		output.RenderOutput(output.Table{
+		r := output.RenderOutput(output.Table{
 			Header: []string{
 				"Name",
 				"Webhook",
@@ -201,6 +203,7 @@ var listProjectSlacksCmd = &cobra.Command{
 			},
 			Data: data,
 		}, outputOptions)
+		fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		return nil
 	},
 }
@@ -243,7 +246,7 @@ var listAllSlacksCmd = &cobra.Command{
 				}
 			}
 		}
-		output.RenderOutput(output.Table{
+		r := output.RenderOutput(output.Table{
 			Header: []string{
 				"Project",
 				"Name",
@@ -252,6 +255,7 @@ var listAllSlacksCmd = &cobra.Command{
 			},
 			Data: data,
 		}, outputOptions)
+		fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		return nil
 	},
 }
@@ -296,7 +300,8 @@ var deleteProjectSlackNotificationCmd = &cobra.Command{
 			resultData := output.Result{
 				Result: "success",
 			}
-			output.RenderResult(resultData, outputOptions)
+			r := output.RenderResult(resultData, outputOptions)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		}
 		return nil
 	},
@@ -337,7 +342,8 @@ var deleteSlackNotificationCmd = &cobra.Command{
 			resultData := output.Result{
 				Result: result.DeleteNotification,
 			}
-			output.RenderResult(resultData, outputOptions)
+			r := output.RenderResult(resultData, outputOptions)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		}
 		return nil
 	},
@@ -409,7 +415,7 @@ var updateSlackNotificationCmd = &cobra.Command{
 					returnNonEmptyString(fmt.Sprintf("%v", result.Channel)),
 				},
 			}
-			output.RenderOutput(output.Table{
+			r := output.RenderOutput(output.Table{
 				Header: []string{
 					"ID",
 					"Name",
@@ -418,6 +424,7 @@ var updateSlackNotificationCmd = &cobra.Command{
 				},
 				Data: data,
 			}, outputOptions)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		}
 		return nil
 	},

--- a/cmd/notificationsteams.go
+++ b/cmd/notificationsteams.go
@@ -79,7 +79,7 @@ It does not configure a project to send notifications to Microsoft Teams though,
 				notificationData = append(notificationData, "-")
 			}
 			data = append(data, notificationData)
-			output.RenderOutput(output.Table{
+			r := output.RenderOutput(output.Table{
 				Header: []string{
 					"ID",
 					"Name",
@@ -88,6 +88,7 @@ It does not configure a project to send notifications to Microsoft Teams though,
 				},
 				Data: data,
 			}, outputOptions)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		}
 		return nil
 	},
@@ -135,7 +136,8 @@ This command is used to add an existing Microsoft Teams notification in Lagoon t
 			resultData := output.Result{
 				Result: "success",
 			}
-			output.RenderResult(resultData, outputOptions)
+			r := output.RenderResult(resultData, outputOptions)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		}
 		return nil
 	},
@@ -185,13 +187,14 @@ var listProjectMicrosoftTeamsCmd = &cobra.Command{
 				})
 			}
 		}
-		output.RenderOutput(output.Table{
+		r := output.RenderOutput(output.Table{
 			Header: []string{
 				"Name",
 				"Webhook",
 			},
 			Data: data,
 		}, outputOptions)
+		fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		return nil
 	},
 }
@@ -233,7 +236,7 @@ var listAllMicrosoftTeamsCmd = &cobra.Command{
 				}
 			}
 		}
-		output.RenderOutput(output.Table{
+		r := output.RenderOutput(output.Table{
 			Header: []string{
 				"Project",
 				"Name",
@@ -241,6 +244,7 @@ var listAllMicrosoftTeamsCmd = &cobra.Command{
 			},
 			Data: data,
 		}, outputOptions)
+		fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		return nil
 	},
 }
@@ -285,7 +289,8 @@ var deleteProjectMicrosoftTeamsNotificationCmd = &cobra.Command{
 			resultData := output.Result{
 				Result: "success",
 			}
-			output.RenderResult(resultData, outputOptions)
+			r := output.RenderResult(resultData, outputOptions)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		}
 		return nil
 	},
@@ -326,7 +331,8 @@ var deleteMicrosoftTeamsNotificationCmd = &cobra.Command{
 			resultData := output.Result{
 				Result: result.DeleteNotification,
 			}
-			output.RenderResult(resultData, outputOptions)
+			r := output.RenderResult(resultData, outputOptions)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		}
 		return nil
 	},
@@ -392,7 +398,7 @@ var updateMicrosoftTeamsNotificationCmd = &cobra.Command{
 					returnNonEmptyString(fmt.Sprintf("%v", result.Webhook)),
 				},
 			}
-			output.RenderOutput(output.Table{
+			r := output.RenderOutput(output.Table{
 				Header: []string{
 					"ID",
 					"Name",
@@ -400,6 +406,7 @@ var updateMicrosoftTeamsNotificationCmd = &cobra.Command{
 				},
 				Data: data,
 			}, outputOptions)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		}
 		return nil
 	},

--- a/cmd/notificationswebhook.go
+++ b/cmd/notificationswebhook.go
@@ -79,7 +79,7 @@ It does not configure a project to send notifications to webhook though, you nee
 				notificationData = append(notificationData, "-")
 			}
 			data = append(data, notificationData)
-			output.RenderOutput(output.Table{
+			r := output.RenderOutput(output.Table{
 				Header: []string{
 					"ID",
 					"Name",
@@ -88,6 +88,7 @@ It does not configure a project to send notifications to webhook though, you nee
 				},
 				Data: data,
 			}, outputOptions)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		}
 		return nil
 	},
@@ -135,7 +136,8 @@ This command is used to add an existing webhook notification in Lagoon to a proj
 			resultData := output.Result{
 				Result: "success",
 			}
-			output.RenderResult(resultData, outputOptions)
+			r := output.RenderResult(resultData, outputOptions)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		}
 		return nil
 	},
@@ -185,13 +187,14 @@ var listProjectWebhooksCmd = &cobra.Command{
 				})
 			}
 		}
-		output.RenderOutput(output.Table{
+		r := output.RenderOutput(output.Table{
 			Header: []string{
 				"Name",
 				"Webhook",
 			},
 			Data: data,
 		}, outputOptions)
+		fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		return nil
 	},
 }
@@ -233,7 +236,7 @@ var listAllWebhooksCmd = &cobra.Command{
 				}
 			}
 		}
-		output.RenderOutput(output.Table{
+		r := output.RenderOutput(output.Table{
 			Header: []string{
 				"Project",
 				"Name",
@@ -241,6 +244,7 @@ var listAllWebhooksCmd = &cobra.Command{
 			},
 			Data: data,
 		}, outputOptions)
+		fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		return nil
 	},
 }
@@ -285,7 +289,8 @@ var deleteProjectWebhookNotificationCmd = &cobra.Command{
 			resultData := output.Result{
 				Result: "success",
 			}
-			output.RenderResult(resultData, outputOptions)
+			r := output.RenderResult(resultData, outputOptions)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		}
 		return nil
 	},
@@ -326,7 +331,8 @@ var deleteWebhookNotificationCmd = &cobra.Command{
 			resultData := output.Result{
 				Result: result.DeleteNotification,
 			}
-			output.RenderResult(resultData, outputOptions)
+			r := output.RenderResult(resultData, outputOptions)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		}
 		return nil
 	},
@@ -392,7 +398,7 @@ var updateWebhookNotificationCmd = &cobra.Command{
 					returnNonEmptyString(fmt.Sprintf("%v", result.Webhook)),
 				},
 			}
-			output.RenderOutput(output.Table{
+			r := output.RenderOutput(output.Table{
 				Header: []string{
 					"ID",
 					"Name",
@@ -400,6 +406,7 @@ var updateWebhookNotificationCmd = &cobra.Command{
 				},
 				Data: data,
 			}, outputOptions)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		}
 		return nil
 	},

--- a/cmd/organization.go
+++ b/cmd/organization.go
@@ -90,7 +90,8 @@ var addOrganizationCmd = &cobra.Command{
 				"Organization Name": organizationName,
 			},
 		}
-		output.RenderResult(resultData, outputOptions)
+		r := output.RenderResult(resultData, outputOptions)
+		fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		return nil
 	},
 }
@@ -139,7 +140,8 @@ var deleteOrganizationCmd = &cobra.Command{
 			resultData := output.Result{
 				Result: organization.Name,
 			}
-			output.RenderResult(resultData, outputOptions)
+			r := output.RenderResult(resultData, outputOptions)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		}
 		return nil
 	},
@@ -229,7 +231,8 @@ var updateOrganizationCmd = &cobra.Command{
 				"Organization Name": result.Name,
 			},
 		}
-		output.RenderResult(resultData, outputOptions)
+		r := output.RenderResult(resultData, outputOptions)
+		fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		return nil
 	},
 }

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -50,7 +50,8 @@ var deleteProjectCmd = &cobra.Command{
 			resultData := output.Result{
 				Result: "success",
 			}
-			output.RenderResult(resultData, outputOptions)
+			r := output.RenderResult(resultData, outputOptions)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		}
 		return nil
 	},
@@ -203,7 +204,8 @@ var addProjectCmd = &cobra.Command{
 		if organizationName != "" {
 			resultData.ResultData["Organization"] = organizationName
 		}
-		output.RenderResult(resultData, outputOptions)
+		r := output.RenderResult(resultData, outputOptions)
+		fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		return nil
 	},
 }
@@ -391,7 +393,8 @@ var updateProjectCmd = &cobra.Command{
 				"Project Name": projectUpdate.Name,
 			},
 		}
-		output.RenderResult(resultData, outputOptions)
+		r := output.RenderResult(resultData, outputOptions)
+		fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		return nil
 	},
 }
@@ -460,10 +463,11 @@ var listProjectByMetadata = &cobra.Command{
 		if showMetadata {
 			header = append(header, "Metadata")
 		}
-		output.RenderOutput(output.Table{
+		r := output.RenderOutput(output.Table{
 			Header: header,
 			Data:   data,
 		}, outputOptions)
+		fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		return nil
 	},
 }
@@ -510,10 +514,11 @@ var getProjectMetadata = &cobra.Command{
 			"Key",
 			"Value",
 		}
-		output.RenderOutput(output.Table{
+		r := output.RenderOutput(output.Table{
 			Header: header,
 			Data:   data,
 		}, outputOptions)
+		fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		return nil
 	},
 }
@@ -565,7 +570,7 @@ var updateProjectMetadata = &cobra.Command{
 				returnNonEmptyString(fmt.Sprintf("%v", projectResult.Name)),
 				returnNonEmptyString(fmt.Sprintf("%v", string(metaData))),
 			})
-			output.RenderOutput(output.Table{
+			r := output.RenderOutput(output.Table{
 				Header: []string{
 					"ID",
 					"Name",
@@ -573,6 +578,7 @@ var updateProjectMetadata = &cobra.Command{
 				},
 				Data: data,
 			}, outputOptions)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		}
 		return nil
 	},
@@ -621,7 +627,7 @@ var deleteProjectMetadataByKey = &cobra.Command{
 				returnNonEmptyString(fmt.Sprintf("%v", projectResult.Name)),
 				returnNonEmptyString(fmt.Sprintf("%v", string(metaData))),
 			})
-			output.RenderOutput(output.Table{
+			r := output.RenderOutput(output.Table{
 				Header: []string{
 					"ID",
 					"Name",
@@ -629,6 +635,7 @@ var deleteProjectMetadataByKey = &cobra.Command{
 				},
 				Data: data,
 			}, outputOptions)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		}
 		return nil
 	},
@@ -694,7 +701,8 @@ var removeProjectFromOrganizationCmd = &cobra.Command{
 					"Organization Name": organizationName,
 				},
 			}
-			output.RenderResult(resultData, outputOptions)
+			r := output.RenderResult(resultData, outputOptions)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		}
 		return nil
 	},

--- a/cmd/retrieve.go
+++ b/cmd/retrieve.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"github.com/uselagoon/lagoon-cli/pkg/output"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -59,7 +60,9 @@ You can check the status of the backup using the list backups or get backup comm
 				}
 				return err
 			}
-			fmt.Println("successfully created restore with ID:", result.ID)
+			resultData := output.Result{Result: fmt.Sprintf("successfully created restore with ID: %d", result.ID)}
+			r := output.RenderResult(resultData, outputOptions)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		}
 		return nil
 	},

--- a/cmd/tasks.go
+++ b/cmd/tasks.go
@@ -79,7 +79,8 @@ var getTaskByID = &cobra.Command{
 			dataMain.Header = append(dataMain.Header, "Logs")
 			dataMain.Data[0] = append(dataMain.Data[0], returnNonEmptyString(result.Logs))
 		}
-		output.RenderOutput(dataMain, outputOptions)
+		r := output.RenderOutput(dataMain, outputOptions)
+		fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		return nil
 	},
 }
@@ -181,7 +182,8 @@ var runDrushArchiveDump = &cobra.Command{
 				Result:     "success",
 				ResultData: resultMap["taskDrushArchiveDump"].(map[string]interface{}),
 			}
-			output.RenderResult(resultData, outputOptions)
+			r := output.RenderResult(resultData, outputOptions)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		} else {
 			return fmt.Errorf("unable to determine status of task")
 		}
@@ -249,7 +251,8 @@ var runDrushSQLDump = &cobra.Command{
 				Result:     "success",
 				ResultData: resultMap["taskDrushSqlDump"].(map[string]interface{}),
 			}
-			output.RenderResult(resultData, outputOptions)
+			r := output.RenderResult(resultData, outputOptions)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		} else {
 			return fmt.Errorf("unable to determine status of task")
 		}
@@ -317,7 +320,8 @@ var runDrushCacheClear = &cobra.Command{
 				Result:     "success",
 				ResultData: resultMap["taskDrushCacheClear"].(map[string]interface{}),
 			}
-			output.RenderResult(resultData, outputOptions)
+			r := output.RenderResult(resultData, outputOptions)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		} else {
 			return fmt.Errorf("unable to determine status of task")
 		}
@@ -388,7 +392,8 @@ Direct:
 				"status": taskResult.Status,
 			},
 		}
-		output.RenderResult(resultData, outputOptions)
+		r := output.RenderResult(resultData, outputOptions)
+		fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		return nil
 	},
 }
@@ -489,7 +494,8 @@ Path:
 				"id": taskResult.ID,
 			},
 		}
-		output.RenderResult(resultData, outputOptions)
+		r := output.RenderResult(resultData, outputOptions)
+		fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		return nil
 	},
 }
@@ -549,7 +555,8 @@ var uploadFilesToTask = &cobra.Command{
 				},
 			},
 		}
-		output.RenderOutput(dataMain, outputOptions)
+		r := output.RenderOutput(dataMain, outputOptions)
+		fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		return nil
 	},
 }

--- a/cmd/users.go
+++ b/cmd/users.go
@@ -121,7 +121,8 @@ var addUserCmd = &cobra.Command{
 				"id": user.ID,
 			},
 		}
-		output.RenderResult(resultData, outputOptions)
+		r := output.RenderResult(resultData, outputOptions)
+		fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		return nil
 	},
 }
@@ -199,7 +200,8 @@ Add key by defining key value, but not specifying a key name (will default to tr
 				"ID": result.ID,
 			},
 		}
-		output.RenderResult(resultData, outputOptions)
+		r := output.RenderResult(resultData, outputOptions)
+		fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		return nil
 	},
 }
@@ -241,7 +243,8 @@ var deleteSSHKeyCmd = &cobra.Command{
 			resultData := output.Result{
 				Result: "success",
 			}
-			output.RenderResult(resultData, outputOptions)
+			r := output.RenderResult(resultData, outputOptions)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		}
 		return nil
 	},
@@ -287,7 +290,8 @@ var deleteUserCmd = &cobra.Command{
 			resultData := output.Result{
 				Result: "success",
 			}
-			output.RenderResult(resultData, outputOptions)
+			r := output.RenderResult(resultData, outputOptions)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		}
 		return nil
 	},
@@ -362,7 +366,8 @@ var updateUserCmd = &cobra.Command{
 				"ID": user.ID,
 			},
 		}
-		output.RenderResult(resultData, outputOptions)
+		r := output.RenderResult(resultData, outputOptions)
+		fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		return nil
 	},
 }
@@ -423,7 +428,8 @@ var getUserKeysCmd = &cobra.Command{
 		}
 
 		outputOptions.MultiLine = true
-		output.RenderOutput(dataMain, outputOptions)
+		r := output.RenderOutput(dataMain, outputOptions)
+		fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		return nil
 	},
 }
@@ -492,7 +498,8 @@ var getAllUserKeysCmd = &cobra.Command{
 			Data:   data,
 		}
 		outputOptions.MultiLine = true
-		output.RenderOutput(dataMain, outputOptions)
+		r := output.RenderOutput(dataMain, outputOptions)
+		fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		return nil
 	},
 }
@@ -568,7 +575,8 @@ var addAdministratorToOrganizationCmd = &cobra.Command{
 				"Organization Name": organizationName,
 			},
 		}
-		output.RenderResult(resultData, outputOptions)
+		r := output.RenderResult(resultData, outputOptions)
+		fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		return nil
 	},
 }
@@ -635,7 +643,8 @@ var removeAdministratorFromOrganizationCmd = &cobra.Command{
 					"Organization Name": organizationName,
 				},
 			}
-			output.RenderResult(resultData, outputOptions)
+			r := output.RenderResult(resultData, outputOptions)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		}
 		return nil
 	},
@@ -682,7 +691,8 @@ var resetPasswordCmd = &cobra.Command{
 			resultData := output.Result{
 				Result: "success",
 			}
-			output.RenderResult(resultData, outputOptions)
+			r := output.RenderResult(resultData, outputOptions)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		}
 		return nil
 	},

--- a/cmd/variables.go
+++ b/cmd/variables.go
@@ -85,10 +85,11 @@ var addVariableCmd = &cobra.Command{
 			header = append(header, "Scope")
 			header = append(header, "Name")
 			header = append(header, "Value")
-			output.RenderOutput(output.Table{
+			r := output.RenderOutput(output.Table{
 				Header: header,
 				Data:   data,
 			}, outputOptions)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		} else {
 			output.RenderInfo(fmt.Sprintf("variable %s remained unchanged", varName), outputOptions)
 		}
@@ -142,7 +143,8 @@ var deleteVariableCmd = &cobra.Command{
 			resultData := output.Result{
 				Result: deleteResult.DeleteEnvVar,
 			}
-			output.RenderResult(resultData, outputOptions)
+			r := output.RenderResult(resultData, outputOptions)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		}
 		return nil
 	},

--- a/cmd/whoami.go
+++ b/cmd/whoami.go
@@ -86,12 +86,13 @@ This is useful if you have multiple keys or accounts in multiple lagoons and nee
 				}
 				keys = append(keys, keyData)
 			}
-			output.RenderOutput(output.Table{
+			r := output.RenderOutput(output.Table{
 				Header: header,
 				Data:   keys,
 			}, outputOptions)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		} else {
-			output.RenderOutput(output.Table{
+			r := output.RenderOutput(output.Table{
 				Header: []string{
 					"ID",
 					"Email",
@@ -109,6 +110,7 @@ This is useful if you have multiple keys or accounts in multiple lagoons and nee
 					},
 				},
 			}, outputOptions)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		}
 
 		return nil


### PR DESCRIPTION
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

Changes the `render` functions in the `Output` package to return strings, allowing for the output to be captured in command testing (here https://github.com/uselagoon/lagoon-cli/pull/358). Updates all relevant commands to the use the modified `render` functions.