### PR TITLE
refactor: convert uint flags to boolean, other fixes and improvements

### DIFF
--- a/cmd/get.go
+++ b/cmd/get.go
@@ -69,27 +69,27 @@ var getProjectCmd = &cobra.Command{
 			return nil
 		}
 
-		DevEnvironments := 0
+		devEnvironments := 0
 		productionRoute := ""
-		deploymentsDisabled, err := strconv.ParseBool(strconv.Itoa(int(project.DeploymentsDisabled)))
+		deploymentsDisabled, err := strconv.ParseBool(strconv.Itoa(int(*project.DeploymentsDisabled)))
 		if err != nil {
 			return err
 		}
-		autoIdle, err := strconv.ParseBool(strconv.Itoa(int(project.AutoIdle)))
+		autoIdle, err := strconv.ParseBool(strconv.Itoa(int(*project.AutoIdle)))
 		if err != nil {
 			return err
 		}
-		factsUI, err := strconv.ParseBool(strconv.Itoa(int(project.FactsUI)))
+		factsUI, err := strconv.ParseBool(strconv.Itoa(int(*project.FactsUI)))
 		if err != nil {
 			return err
 		}
-		problemsUI, err := strconv.ParseBool(strconv.Itoa(int(project.ProblemsUI)))
+		problemsUI, err := strconv.ParseBool(strconv.Itoa(int(*project.ProblemsUI)))
 		if err != nil {
 			return err
 		}
 		for _, environment := range project.Environments {
 			if environment.EnvironmentType == "development" {
-				DevEnvironments++
+				devEnvironments++
 			}
 			if environment.EnvironmentType == "production" {
 				productionRoute = environment.Route
@@ -102,7 +102,7 @@ var getProjectCmd = &cobra.Command{
 			returnNonEmptyString(fmt.Sprintf("%v", project.GitURL)),
 			returnNonEmptyString(fmt.Sprintf("%v", project.ProductionEnvironment)),
 			returnNonEmptyString(fmt.Sprintf("%v", productionRoute)),
-			returnNonEmptyString(fmt.Sprintf("%v/%v", DevEnvironments, project.DevelopmentEnvironmentsLimit)),
+			returnNonEmptyString(fmt.Sprintf("%v/%v", devEnvironments, *project.DevelopmentEnvironmentsLimit)),
 		}
 		projHeader := []string{"ID", "ProjectName", "GitUrl", "ProductionEnvironment", "ProductionRoute", "DevEnvironments"}
 		if wide {

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -1183,7 +1183,12 @@ var ListOrganizationAdminsCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-
+		if len(*users) == 0 {
+			outputOptions.Error = fmt.Sprintf("No associated users found for organization '%s'\n", organizationName)
+			r := output.RenderOutput(output.Table{Data: []output.Data{[]string{}}}, outputOptions)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
+			return nil
+		}
 		data := []output.Data{}
 		for _, user := range *users {
 			role := "viewer"

--- a/cmd/shared.go
+++ b/cmd/shared.go
@@ -80,6 +80,14 @@ func nullUintCheck(i uint) *uint {
 	return &i
 }
 
+func nullBoolToUint(b bool) *uint {
+	t := uint(0)
+	if b {
+		t = uint(1)
+	}
+	return &t
+}
+
 func nullIntCheck(i int) *int {
 	if i == 0 {
 		return nil

--- a/cmd/users.go
+++ b/cmd/users.go
@@ -538,10 +538,12 @@ var addAdministratorToOrganizationCmd = &cobra.Command{
 		}
 		switch strings.ToLower(role) {
 		case "viewer":
+		case "admin":
+			userInput.Admin = true
 		case "owner":
 			userInput.Owner = true
 		default:
-			return fmt.Errorf(`role '%s' is not valid - valid roles include "viewer", "owner"`, role)
+			return fmt.Errorf(`role '%s' is not valid - valid roles include "viewer", "admin", or "owner"`, role)
 		}
 
 		current := lagoonCLIConfig.Current
@@ -717,7 +719,7 @@ func init() {
 	getAllUserKeysCmd.Flags().StringP("name", "N", "", "Name of the group to list users in (if not specified, will default to all groups)")
 	addAdministratorToOrganizationCmd.Flags().StringP("organization-name", "O", "", "Name of the organization")
 	addAdministratorToOrganizationCmd.Flags().StringP("email", "E", "", "Email address of the user")
-	addAdministratorToOrganizationCmd.Flags().StringP("role", "R", "", "Role in the organization [owner, viewer]")
+	addAdministratorToOrganizationCmd.Flags().StringP("role", "R", "", "Role in the organization [owner, admin, viewer]")
 	removeAdministratorFromOrganizationCmd.Flags().StringP("organization-name", "O", "", "Name of the organization")
 	removeAdministratorFromOrganizationCmd.Flags().StringP("email", "E", "", "Email address of the user")
 	resetPasswordCmd.Flags().StringP("email", "E", "", "Email address of the user")

--- a/docs/commands/lagoon_add_organization-administrator.md
+++ b/docs/commands/lagoon_add_organization-administrator.md
@@ -16,7 +16,7 @@ lagoon add organization-administrator [flags]
   -E, --email string               Email address of the user
   -h, --help                       help for organization-administrator
   -O, --organization-name string   Name of the organization
-  -R, --role string                Role in the organization [owner, viewer]
+  -R, --role string                Role in the organization [owner, admin, viewer]
 ```
 
 ### Options inherited from parent commands

--- a/docs/commands/lagoon_add_project.md
+++ b/docs/commands/lagoon_add_project.md
@@ -14,7 +14,7 @@ lagoon add project [flags]
 ### Options
 
 ```
-  -a, --auto-idle uint                          Auto idle setting of the project
+  -a, --auto-idle                               Auto idle setting of the project. Set to enable, --auto-idle=false to disable
   -b, --branches string                         Which branches should be deployed
       --build-image string                      Build Image for the project
   -S, --deploytarget uint                       Reference to Deploytarget(Kubernetes) target this Project should be deployed to
@@ -31,7 +31,7 @@ lagoon add project [flags]
   -m, --pullrequests string                     Which Pull Requests should be deployed
   -Z, --router-pattern string                   Router pattern of the project, e.g. '${service}-${environment}-${project}.lagoon.example.com'
       --standby-production-environment string   Which environment(the name) should be marked as the standby production environment
-  -C, --storage-calc uint                       Should storage for this environment be calculated
+  -C, --storage-calc                            Should storage for this environment be calculated. Set to enable, --storage-calc=false to disable
   -s, --subfolder string                        Set if the .lagoon.yml should be found in a subfolder useful if you have multiple Lagoon projects per Git Repository
 ```
 

--- a/docs/commands/lagoon_list_deploytargets.md
+++ b/docs/commands/lagoon_list_deploytargets.md
@@ -13,7 +13,9 @@ lagoon list deploytargets [flags]
 ### Options
 
 ```
-  -h, --help   help for deploytargets
+  -h, --help         help for deploytargets
+      --show-token   Display the token for deploytargets
+      --wide         Display additional information about deploytargets
 ```
 
 ### Options inherited from parent commands

--- a/docs/commands/lagoon_update_project.md
+++ b/docs/commands/lagoon_update_project.md
@@ -9,28 +9,28 @@ lagoon update project [flags]
 ### Options
 
 ```
-  -a, --auto-idle uint                          Auto idle setting of the project
+  -a, --auto-idle                               Auto idle setting of the project. Set to enable, --auto-idle=false to disable
       --availability string                     Availability of the project
   -b, --branches string                         Which branches should be deployed
       --build-image string                      Build Image for the project. Set to 'null' to remove the build image
-      --deployments-disabled uint               Admin only flag for disabling deployments on a project, 1 to disable deployments, 0 to enable
+      --deployments-disabled                    Admin only flag for disabling deployments on a project. Set to disable deployments, --deployments-disabled=false to enable
   -S, --deploytarget uint                       Reference to Deploytarget(Kubernetes) this Project should be deployed to
   -o, --deploytarget-project-pattern string     Pattern of Deploytarget(Kubernetes) Project/Namespace that should be generated
       --development-build-priority uint         Set the priority of the development build
   -L, --development-environments-limit uint     How many environments can be deployed at one time
-      --facts-ui uint                           Enables the Lagoon insights Facts tab in the UI. Set to 1 to enable, 0 to disable
+      --facts-ui                                Enables the Lagoon insights Facts tab in the UI. Set to enable, --facts-ui=false to disable
   -g, --git-url string                          GitURL of the project
   -h, --help                                    help for project
   -j, --json string                             JSON string to patch
   -N, --name string                             Change the name of the project by specifying a new name (careful!)
   -I, --private-key string                      Private key to use for the project
-      --problems-ui uint                        Enables the Lagoon insights Problems tab in the UI. Set to 1 to enable, 0 to disable
+      --problems-ui                             Enables the Lagoon insights Problems tab in the UI. Set to enable, --problems-ui=false to disable
       --production-build-priority uint          Set the priority of the production build
   -E, --production-environment string           Which environment(the name) should be marked as the production environment
   -m, --pullrequests string                     Which Pull Requests should be deployed
   -Z, --router-pattern string                   Router pattern of the project, e.g. '${service}-${environment}-${project}.lagoon.example.com'
       --standby-production-environment string   Which environment(the name) should be marked as the standby production environment
-  -C, --storage-calc uint                       Should storage for this environment be calculated
+  -C, --storage-calc                            Should storage for this environment be calculated. Set to enable, --storage-calc=false to disable
   -s, --subfolder string                        Set if the .lagoon.yml should be found in a subfolder useful if you have multiple Lagoon projects per Git Repository
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.2
-	github.com/uselagoon/machinery v0.0.24
+	github.com/uselagoon/machinery v0.0.27
 	golang.org/x/crypto v0.21.0
 	golang.org/x/term v0.18.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -66,8 +66,8 @@ github.com/stretchr/testify v1.7.4/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/uselagoon/machinery v0.0.24 h1:Kea7eQiwqrlF1NnG4YmV5dMNM1NxuhiY1vhoahEFkQA=
-github.com/uselagoon/machinery v0.0.24/go.mod h1:NbgtEofjK2XY0iUpk9aMYazIo+W/NI56+UF72jv8zVY=
+github.com/uselagoon/machinery v0.0.27 h1:luIrdAiVhCPgxAwh2gtPm5iepMnXyTR6sNbuLuBhk80=
+github.com/uselagoon/machinery v0.0.27/go.mod h1:NbgtEofjK2XY0iUpk9aMYazIo+W/NI56+UF72jv8zVY=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

Converts some previously uint value flags (0/1) that represent booleans to be actual booleans, and fixes the way the values are added to the inputs of the mutations to prevent them being added by default and only added if they're defined specifically (either as true, or as a specific `--flag=false` value.

Additional fixes to the deploytarget list too to reduce how much data is returned, with new `--wide` and `--show-token` flag. These commands are only supported for `platform-owner`, just makes it easier to read the output.

Also adds the new `admin` role support from Lagoon v2.20.0 to organization owners commands, so that admins can be managed via the CLI now along with previous owner and viewer roles.