### PR TITLE
fix: rename list organization-administrator command to match others

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -1151,9 +1151,9 @@ var ListOrganizationUsersCmd = &cobra.Command{
 	},
 }
 
-var ListOrganizationAdminsCmd = &cobra.Command{
-	Use:     "organization-admins",
-	Aliases: []string{"org-a"},
+var listOrganizationAdminsCmd = &cobra.Command{
+	Use:     "organization-admininstrators",
+	Aliases: []string{"organization-admins", "org-admins", "org-a"},
 	Short:   "List admins in an organization",
 	PreRunE: func(_ *cobra.Command, _ []string) error {
 		return validateTokenE(cmdLagoon)
@@ -1285,7 +1285,7 @@ func init() {
 	listCmd.AddCommand(listUsersGroupsCmd)
 	listCmd.AddCommand(listOrganizationProjectsCmd)
 	listCmd.AddCommand(ListOrganizationUsersCmd)
-	listCmd.AddCommand(ListOrganizationAdminsCmd)
+	listCmd.AddCommand(listOrganizationAdminsCmd)
 	listCmd.AddCommand(listOrganizationGroupsCmd)
 	listCmd.AddCommand(listOrganizationDeployTargetsCmd)
 	listCmd.AddCommand(listOrganizationsCmd)
@@ -1298,7 +1298,7 @@ func init() {
 	listVariablesCmd.Flags().BoolP("reveal", "", false, "Reveal the variable values")
 	listOrganizationProjectsCmd.Flags().StringP("organization-name", "O", "", "Name of the organization to list associated projects for")
 	ListOrganizationUsersCmd.Flags().StringP("organization-name", "O", "", "Name of the organization to list associated users for")
-	ListOrganizationAdminsCmd.Flags().StringP("organization-name", "O", "", "Name of the organization to list associated users for")
+	listOrganizationAdminsCmd.Flags().StringP("organization-name", "O", "", "Name of the organization to list associated users for")
 	listOrganizationGroupsCmd.Flags().StringP("organization-name", "O", "", "Name of the organization to list associated groups for")
 	listOrganizationDeployTargetsCmd.Flags().StringP("organization-name", "O", "", "Name of the organization to list associated deploy targets for")
 	listOrganizationDeployTargetsCmd.Flags().Uint("id", 0, "ID of the organization to list associated deploy targets for")

--- a/cmd/users.go
+++ b/cmd/users.go
@@ -506,7 +506,7 @@ var getAllUserKeysCmd = &cobra.Command{
 
 var addAdministratorToOrganizationCmd = &cobra.Command{
 	Use:     "organization-administrator",
-	Aliases: []string{"org-admin"},
+	Aliases: []string{"organization-admin", "org-admin", "org-a"},
 	Short:   "Add an administrator to an Organization",
 	Long:    "Add an administrator to an Organization. If the role flag is not provided users will be added as viewers",
 	PreRunE: func(_ *cobra.Command, _ []string) error {
@@ -585,7 +585,7 @@ var addAdministratorToOrganizationCmd = &cobra.Command{
 
 var removeAdministratorFromOrganizationCmd = &cobra.Command{
 	Use:     "organization-administrator",
-	Aliases: []string{"org-admin"},
+	Aliases: []string{"organization-admin", "org-admin", "org-a"},
 	Short:   "Remove an administrator from an Organization",
 	PreRunE: func(_ *cobra.Command, _ []string) error {
 		return validateTokenE(lagoonCLIConfig.Current)

--- a/docs/commands/lagoon_list.md
+++ b/docs/commands/lagoon_list.md
@@ -43,7 +43,7 @@ List projects, environments, deployments, variables or notifications
 * [lagoon list groups](lagoon_list_groups.md)	 - List groups you have access to (alias: g)
 * [lagoon list invokable-tasks](lagoon_list_invokable-tasks.md)	 - Print a list of invokable tasks
 * [lagoon list notification](lagoon_list_notification.md)	 - List all notifications or notifications on projects
-* [lagoon list organization-admins](lagoon_list_organization-admins.md)	 - List admins in an organization
+* [lagoon list organization-admininstrators](lagoon_list_organization-admininstrators.md)	 - List admins in an organization
 * [lagoon list organization-deploytargets](lagoon_list_organization-deploytargets.md)	 - List deploy targets in an organization
 * [lagoon list organization-groups](lagoon_list_organization-groups.md)	 - List groups in an organization
 * [lagoon list organization-projects](lagoon_list_organization-projects.md)	 - List projects in an organization

--- a/docs/commands/lagoon_list_organization-admininstrators.md
+++ b/docs/commands/lagoon_list_organization-admininstrators.md
@@ -1,15 +1,15 @@
-## lagoon list organization-admins
+## lagoon list organization-admininstrators
 
 List admins in an organization
 
 ```
-lagoon list organization-admins [flags]
+lagoon list organization-admininstrators [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help                       help for organization-admins
+  -h, --help                       help for organization-admininstrators
   -O, --organization-name string   Name of the organization to list associated users for
 ```
 


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

Just a small fix to the `list organization-administrators` command to rename it from `list organization-admins` and updated the aliases of other commands