### PR TITLE
Fix: Adds better handling for nil results

### DIFF
--- a/cmd/deploytargetconfig.go
+++ b/cmd/deploytargetconfig.go
@@ -239,7 +239,7 @@ var deleteDeployTargetConfigCmd = &cobra.Command{
 			return err
 		}
 		if project.Name == "" {
-			outputOptions.Error = fmt.Sprintf("No details for project '%s'", cmdProjectName)
+			outputOptions.Error = fmt.Sprintf("No details for project '%s'\n", cmdProjectName)
 			output.RenderError(outputOptions.Error, outputOptions)
 			return nil
 		}
@@ -291,13 +291,17 @@ var listDeployTargetConfigsCmd = &cobra.Command{
 			return err
 		}
 		if project.Name == "" {
-			outputOptions.Error = fmt.Sprintf("No details for project '%s'", cmdProjectName)
+			outputOptions.Error = fmt.Sprintf("No details for project '%s'\n", cmdProjectName)
 			output.RenderError(outputOptions.Error, outputOptions)
 			return nil
 		}
 		deployTargetConfigs, err := lagoon.GetDeployTargetConfigs(context.TODO(), int(project.ID), lc)
 		if err != nil {
 			return err
+		}
+		if len(*deployTargetConfigs) == 0 {
+			handleNilResults("No deploytarget-configs for project '%s'\n", cmd, cmdProjectName)
+			return nil
 		}
 		data := []output.Data{}
 		for _, deployTargetConfig := range *deployTargetConfigs {

--- a/cmd/deploytargetconfig.go
+++ b/cmd/deploytargetconfig.go
@@ -239,9 +239,7 @@ var deleteDeployTargetConfigCmd = &cobra.Command{
 			return err
 		}
 		if project.Name == "" {
-			outputOptions.Error = fmt.Sprintf("No details for project '%s'\n", cmdProjectName)
-			output.RenderError(outputOptions.Error, outputOptions)
-			return nil
+			return handleNilResults("Project '%s' not found\n", cmd, cmdProjectName)
 		}
 
 		if yesNo(fmt.Sprintf("You are attempting to delete deploytarget configuration with id '%d' from project '%s', are you sure?", id, cmdProjectName)) {
@@ -291,17 +289,14 @@ var listDeployTargetConfigsCmd = &cobra.Command{
 			return err
 		}
 		if project.Name == "" {
-			outputOptions.Error = fmt.Sprintf("No details for project '%s'\n", cmdProjectName)
-			output.RenderError(outputOptions.Error, outputOptions)
-			return nil
+			return handleNilResults("Project '%s' not found\n", cmd, cmdProjectName)
 		}
 		deployTargetConfigs, err := lagoon.GetDeployTargetConfigs(context.TODO(), int(project.ID), lc)
 		if err != nil {
 			return err
 		}
 		if len(*deployTargetConfigs) == 0 {
-			handleNilResults("No deploytarget-configs for project '%s'\n", cmd, cmdProjectName)
-			return nil
+			return handleNilResults("No deploytarget-configs for project '%s'\n", cmd, cmdProjectName)
 		}
 		data := []output.Data{}
 		for _, deployTargetConfig := range *deployTargetConfigs {

--- a/cmd/environment.go
+++ b/cmd/environment.go
@@ -214,6 +214,10 @@ var listBackupsCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		if project.Name == "" {
+			handleNilResults("No project found for '%s'\n", cmd, cmdProjectName)
+			return nil
+		}
 		backupsResult, err := lagoon.GetBackupsForEnvironmentByName(context.TODO(), cmdProjectEnvironment, project.ID, lc)
 		if err != nil {
 			return err

--- a/cmd/environment.go
+++ b/cmd/environment.go
@@ -215,8 +215,7 @@ var listBackupsCmd = &cobra.Command{
 			return err
 		}
 		if project.Name == "" {
-			handleNilResults("No project found for '%s'\n", cmd, cmdProjectName)
-			return nil
+			return handleNilResults("No project found for '%s'\n", cmd, cmdProjectName)
 		}
 		backupsResult, err := lagoon.GetBackupsForEnvironmentByName(context.TODO(), cmdProjectEnvironment, project.ID, lc)
 		if err != nil {

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -63,8 +63,7 @@ var getProjectCmd = &cobra.Command{
 		}
 
 		if project.Name == "" {
-			handleNilResults("No details for project '%s'\n", cmd, cmdProjectName)
-			return nil
+			return handleNilResults("No details for project '%s'\n", cmd, cmdProjectName)
 		}
 
 		devEnvironments := 0
@@ -251,11 +250,10 @@ var getEnvironmentCmd = &cobra.Command{
 
 		if project.Name == "" || environment.Name == "" {
 			if project.Name == "" {
-				handleNilResults("Project '%s' not found\n", cmd, cmdProjectName)
+				return handleNilResults("Project '%s' not found\n", cmd, cmdProjectName)
 			} else {
-				handleNilResults("Environment '%s' not found in project '%s'\n", cmd, cmdProjectEnvironment, cmdProjectName)
+				return handleNilResults("Environment '%s' not found in project '%s'\n", cmd, cmdProjectEnvironment, cmdProjectName)
 			}
-			return nil
 		}
 
 		data := []output.Data{}
@@ -329,8 +327,7 @@ var getProjectKeyCmd = &cobra.Command{
 			return err
 		}
 		if project.Name == "" {
-			handleNilResults("No project found for '%s'\n", cmd, cmdProjectName)
-			return nil
+			return handleNilResults("No project found for '%s'\n", cmd, cmdProjectName)
 		}
 
 		projectKey, err := lagoon.GetProjectKeyByName(context.TODO(), cmdProjectName, revealValue, lc)
@@ -338,8 +335,7 @@ var getProjectKeyCmd = &cobra.Command{
 			return err
 		}
 		if projectKey.PublicKey == "" && projectKey.PrivateKey == "" {
-			handleNilResults("No project-key for project '%s'\n", cmd, cmdProjectName)
-			return nil
+			return handleNilResults("No project-key for project '%s'\n", cmd, cmdProjectName)
 		}
 
 		projectKeys := []string{projectKey.PublicKey}
@@ -420,9 +416,9 @@ var getOrganizationCmd = &cobra.Command{
 			strconv.Itoa(int(organization.ID)),
 			organization.Name,
 			organization.Description,
-			strconv.Itoa(int(organization.QuotaProject)),
-			strconv.Itoa(int(organization.QuotaGroup)),
-			strconv.Itoa(int(organization.QuotaNotification)),
+			strconv.Itoa(organization.QuotaProject),
+			strconv.Itoa(organization.QuotaGroup),
+			strconv.Itoa(organization.QuotaNotification),
 		})
 
 		dataMain := output.Table{

--- a/cmd/groups.go
+++ b/cmd/groups.go
@@ -214,9 +214,7 @@ var addProjectToGroupCmd = &cobra.Command{
 			return err
 		}
 		if len(project.Name) == 0 {
-			outputOptions.Error = fmt.Sprintf("Project '%s' not found\n", cmdProjectName)
-			output.RenderError(outputOptions.Error, outputOptions)
-			return nil
+			return handleNilResults("Project '%s' not found\n", cmd, cmdProjectName)
 		}
 		_, err = lagoon.AddProjectToGroup(context.TODO(), projectGroup, lc)
 		if err != nil {
@@ -335,9 +333,7 @@ var deleteProjectFromGroupCmd = &cobra.Command{
 			return err
 		}
 		if len(project.Name) == 0 {
-			outputOptions.Error = fmt.Sprintf("Project '%s' not found\n", cmdProjectName)
-			output.RenderError(outputOptions.Error, outputOptions)
-			return nil
+			return handleNilResults("Project '%s' not found\n", cmd, cmdProjectName)
 		}
 
 		if yesNo(fmt.Sprintf("You are attempting to delete project '%s' from group '%s', are you sure?", projectGroup.Project.Name, projectGroup.Groups[0].Name)) {

--- a/cmd/groups.go
+++ b/cmd/groups.go
@@ -214,7 +214,7 @@ var addProjectToGroupCmd = &cobra.Command{
 			return err
 		}
 		if len(project.Name) == 0 {
-			outputOptions.Error = fmt.Sprintf("Project '%s' not found", cmdProjectName)
+			outputOptions.Error = fmt.Sprintf("Project '%s' not found\n", cmdProjectName)
 			output.RenderError(outputOptions.Error, outputOptions)
 			return nil
 		}
@@ -335,7 +335,7 @@ var deleteProjectFromGroupCmd = &cobra.Command{
 			return err
 		}
 		if len(project.Name) == 0 {
-			outputOptions.Error = fmt.Sprintf("Project '%s' not found", cmdProjectName)
+			outputOptions.Error = fmt.Sprintf("Project '%s' not found\n", cmdProjectName)
 			output.RenderError(outputOptions.Error, outputOptions)
 			return nil
 		}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -93,7 +93,7 @@ var listProjectsCmd = &cobra.Command{
 			data = append(data, projData)
 		}
 		if len(data) == 0 {
-			outputOptions.Error = "No access to any projects in Lagoon\n"
+			return handleNilResults("No access to any projects in Lagoon\n", cmd)
 		}
 		projHeader := []string{"ID", "ProjectName", "GitUrl", "ProductionEnvironment", "ProductionRoute", "DevEnvironments"}
 		// if wide {
@@ -234,7 +234,7 @@ var listGroupsCmd = &cobra.Command{
 			})
 		}
 		if len(data) == 0 {
-			outputOptions.Error = "This account is not in any groups\n"
+			return handleNilResults("This account is not in any groups\n", cmd)
 		}
 		dataMain := output.Table{
 			Header: []string{"ID", "Name"},
@@ -311,11 +311,10 @@ var listGroupProjectsCmd = &cobra.Command{
 		}
 		if len(data) == 0 {
 			if !listAllProjects {
-				handleNilResults("There are no projects in group '%s'\n", cmd, groupName)
+				return handleNilResults("There are no projects in group '%s'\n", cmd, groupName)
 			} else {
-				handleNilResults("There are no projects in any groups\n", cmd)
+				return handleNilResults("There are no projects in any groups\n", cmd)
 			}
-			return nil
 		}
 
 		dataMain := output.Table{
@@ -361,8 +360,7 @@ var listEnvironmentsCmd = &cobra.Command{
 		}
 
 		if len(*environments) == 0 {
-			handleNilResults("No environments found for project '%s'\n", cmd, cmdProjectName)
-			return nil
+			return handleNilResults("No environments found for project '%s'\n", cmd, cmdProjectName)
 		}
 
 		data := []output.Data{}
@@ -457,11 +455,10 @@ var listVariablesCmd = &cobra.Command{
 		}
 		if len(data) == 0 {
 			if cmdProjectEnvironment != "" {
-				handleNilResults("There are no variables for environment '%s' in project '%s'\n", cmd, cmdProjectEnvironment, cmdProjectName)
+				return handleNilResults("There are no variables for environment '%s' in project '%s'\n", cmd, cmdProjectEnvironment, cmdProjectName)
 			} else {
-				handleNilResults("There are no variables for project '%s'\n", cmd, cmdProjectName)
+				return handleNilResults("There are no variables for project '%s'\n", cmd, cmdProjectName)
 			}
-			return nil
 		}
 		r := output.RenderOutput(output.Table{
 			Header: header,
@@ -502,8 +499,7 @@ var listDeploymentsCmd = &cobra.Command{
 			return err
 		}
 		if project.Name == "" {
-			handleNilResults("No project found for '%s'\n", cmd, cmdProjectName)
-			return nil
+			return handleNilResults("No project found for '%s'\n", cmd, cmdProjectName)
 		}
 
 		deployments, err := lagoon.GetDeploymentsByEnvironment(context.TODO(), project.ID, cmdProjectEnvironment, lc)
@@ -525,8 +521,7 @@ var listDeploymentsCmd = &cobra.Command{
 		}
 
 		if len(data) == 0 {
-			handleNilResults("There are no deployments for environment '%s' in project '%s'\n", cmd, cmdProjectEnvironment, cmdProjectName)
-			return nil
+			return handleNilResults("There are no deployments for environment '%s' in project '%s'\n", cmd, cmdProjectEnvironment, cmdProjectName)
 		}
 		dataMain := output.Table{
 			Header: []string{"ID", "RemoteID", "Name", "Status", "Created", "Started", "Completed"},
@@ -568,8 +563,7 @@ var listTasksCmd = &cobra.Command{
 			return err
 		}
 		if project.Name == "" {
-			handleNilResults("No project found for '%s'\n", cmd, cmdProjectName)
-			return nil
+			return handleNilResults("No project found for '%s'\n", cmd, cmdProjectName)
 		}
 
 		tasks, err := lagoon.GetTasksByEnvironment(context.TODO(), project.ID, cmdProjectEnvironment, lc)
@@ -592,8 +586,7 @@ var listTasksCmd = &cobra.Command{
 		}
 
 		if len(data) == 0 {
-			handleNilResults("There are no tasks for environment '%s' in project '%s'\n", cmd, cmdProjectEnvironment, cmdProjectName)
-			return nil
+			return handleNilResults("There are no tasks for environment '%s' in project '%s'\n", cmd, cmdProjectEnvironment, cmdProjectName)
 		}
 		dataMain := output.Table{
 			Header: []string{"ID", "RemoteID", "Name", "Status", "Created", "Started", "Completed", "Service"},
@@ -808,8 +801,7 @@ var listInvokableTasks = &cobra.Command{
 			return err
 		}
 		if project.Name == "" {
-			handleNilResults("No project found for '%s'\n", cmd, cmdProjectName)
-			return nil
+			return handleNilResults("No project found for '%s'\n", cmd, cmdProjectName)
 		}
 		tasks, err := lagoon.GetInvokableAdvancedTaskDefinitionsByEnvironment(context.TODO(), project.ID, cmdProjectEnvironment, lc)
 		if err != nil {
@@ -825,8 +817,7 @@ var listInvokableTasks = &cobra.Command{
 		}
 
 		if len(data) == 0 {
-			handleNilResults("There are no user defined tasks for environment %s\n", cmd, cmdProjectEnvironment)
-			return nil
+			return handleNilResults("There are no user defined tasks for environment %s\n", cmd, cmdProjectEnvironment)
 		}
 		dataMain := output.Table{
 			Header: []string{"Task Name", "Description"},
@@ -877,8 +868,7 @@ var listProjectGroupsCmd = &cobra.Command{
 		}
 
 		if len(projectGroups.Groups) == 0 {
-			handleNilResults("There are no groups for project '%s'\n", cmd, cmdProjectName)
-			return nil
+			return handleNilResults("There are no groups for project '%s'\n", cmd, cmdProjectName)
 		}
 
 		data := []output.Data{}
@@ -945,8 +935,7 @@ var listOrganizationProjectsCmd = &cobra.Command{
 		}
 
 		if len(*orgProjects) == 0 {
-			handleNilResults("No associated projects found for organization '%s'\n", cmd, organizationName)
-			return nil
+			return handleNilResults("No associated projects found for organization '%s'\n", cmd, organizationName)
 		}
 
 		data := []output.Data{}
@@ -1008,8 +997,7 @@ var listOrganizationGroupsCmd = &cobra.Command{
 			return err
 		}
 		if len(*orgGroups) == 0 {
-			handleNilResults("No associated groups found for organization '%s'\n", cmd, organizationName)
-			return nil
+			return handleNilResults("No associated groups found for organization '%s'\n", cmd, organizationName)
 		}
 
 		data := []output.Data{}
@@ -1068,8 +1056,7 @@ var listOrganizationDeployTargetsCmd = &cobra.Command{
 			return err
 		}
 		if len(*deployTargets) == 0 {
-			handleNilResults("No associated deploy targets found for organization '%s'\n", cmd, organizationName)
-			return nil
+			return handleNilResults("No associated deploy targets found for organization '%s'\n", cmd, organizationName)
 		}
 
 		data := []output.Data{}
@@ -1180,8 +1167,7 @@ var listOrganizationAdminsCmd = &cobra.Command{
 			return err
 		}
 		if len(*users) == 0 {
-			handleNilResults("No associated users found for organization '%s'\n", cmd, organizationName)
-			return nil
+			return handleNilResults("No associated users found for organization '%s'\n", cmd, organizationName)
 		}
 		data := []output.Data{}
 		for _, user := range *users {

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -311,12 +311,10 @@ var listGroupProjectsCmd = &cobra.Command{
 		}
 		if len(data) == 0 {
 			if !listAllProjects {
-				outputOptions.Error = fmt.Sprintf("There are no projects in group '%s'\n", groupName)
+				handleNilResults("There are no projects in group '%s'\n", cmd, groupName)
 			} else {
-				outputOptions.Error = "There are no projects in any groups\n"
+				handleNilResults("There are no projects in any groups\n", cmd)
 			}
-			r := output.RenderOutput(output.Table{Data: []output.Data{[]string{}}}, outputOptions)
-			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 			return nil
 		}
 
@@ -363,9 +361,7 @@ var listEnvironmentsCmd = &cobra.Command{
 		}
 
 		if len(*environments) == 0 {
-			outputOptions.Error = fmt.Sprintf("No environments found for project '%s'\n", cmdProjectName)
-			r := output.RenderOutput(output.Table{Data: []output.Data{[]string{}}}, outputOptions)
-			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
+			handleNilResults("No environments found for project '%s'\n", cmd, cmdProjectName)
 			return nil
 		}
 
@@ -461,12 +457,10 @@ var listVariablesCmd = &cobra.Command{
 		}
 		if len(data) == 0 {
 			if cmdProjectEnvironment != "" {
-				outputOptions.Error = fmt.Sprintf("There are no variables for environment '%s' in project '%s'\n", cmdProjectEnvironment, cmdProjectName)
+				handleNilResults("There are no variables for environment '%s' in project '%s'\n", cmd, cmdProjectEnvironment, cmdProjectName)
 			} else {
-				outputOptions.Error = fmt.Sprintf("There are no variables for project '%s'\n", cmdProjectName)
+				handleNilResults("There are no variables for project '%s'\n", cmd, cmdProjectName)
 			}
-			r := output.RenderOutput(output.Table{Data: []output.Data{[]string{}}}, outputOptions)
-			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 			return nil
 		}
 		r := output.RenderOutput(output.Table{
@@ -507,6 +501,10 @@ var listDeploymentsCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		if project.Name == "" {
+			handleNilResults("No project found for '%s'\n", cmd, cmdProjectName)
+			return nil
+		}
 
 		deployments, err := lagoon.GetDeploymentsByEnvironment(context.TODO(), project.ID, cmdProjectEnvironment, lc)
 		if err != nil {
@@ -527,9 +525,7 @@ var listDeploymentsCmd = &cobra.Command{
 		}
 
 		if len(data) == 0 {
-			outputOptions.Error = fmt.Sprintf("There are no deployments for environment '%s' in project '%s'\n", cmdProjectEnvironment, cmdProjectName)
-			r := output.RenderOutput(output.Table{Data: []output.Data{[]string{}}}, outputOptions)
-			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
+			handleNilResults("There are no deployments for environment '%s' in project '%s'\n", cmd, cmdProjectEnvironment, cmdProjectName)
 			return nil
 		}
 		dataMain := output.Table{
@@ -571,6 +567,10 @@ var listTasksCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		if project.Name == "" {
+			handleNilResults("No project found for '%s'\n", cmd, cmdProjectName)
+			return nil
+		}
 
 		tasks, err := lagoon.GetTasksByEnvironment(context.TODO(), project.ID, cmdProjectEnvironment, lc)
 		if err != nil {
@@ -592,9 +592,7 @@ var listTasksCmd = &cobra.Command{
 		}
 
 		if len(data) == 0 {
-			outputOptions.Error = fmt.Sprintf("There are no tasks for environment '%s' in project '%s'\n", cmdProjectEnvironment, cmdProjectName)
-			r := output.RenderOutput(output.Table{Data: []output.Data{[]string{}}}, outputOptions)
-			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
+			handleNilResults("There are no tasks for environment '%s' in project '%s'\n", cmd, cmdProjectEnvironment, cmdProjectName)
 			return nil
 		}
 		dataMain := output.Table{
@@ -809,6 +807,10 @@ var listInvokableTasks = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		if project.Name == "" {
+			handleNilResults("No project found for '%s'\n", cmd, cmdProjectName)
+			return nil
+		}
 		tasks, err := lagoon.GetInvokableAdvancedTaskDefinitionsByEnvironment(context.TODO(), project.ID, cmdProjectEnvironment, lc)
 		if err != nil {
 			return err
@@ -823,9 +825,7 @@ var listInvokableTasks = &cobra.Command{
 		}
 
 		if len(data) == 0 {
-			outputOptions.Error = "There are no user defined tasks for this environment\n"
-			r := output.RenderOutput(output.Table{Data: []output.Data{[]string{}}}, outputOptions)
-			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
+			handleNilResults("There are no user defined tasks for environment %s\n", cmd, cmdProjectEnvironment)
 			return nil
 		}
 		dataMain := output.Table{
@@ -877,9 +877,7 @@ var listProjectGroupsCmd = &cobra.Command{
 		}
 
 		if len(projectGroups.Groups) == 0 {
-			outputOptions.Error = fmt.Sprintf("There are no groups for project '%s'\n", cmdProjectName)
-			r := output.RenderOutput(output.Table{Data: []output.Data{[]string{}}}, outputOptions)
-			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
+			handleNilResults("There are no groups for project '%s'\n", cmd, cmdProjectName)
 			return nil
 		}
 
@@ -947,9 +945,7 @@ var listOrganizationProjectsCmd = &cobra.Command{
 		}
 
 		if len(*orgProjects) == 0 {
-			outputOptions.Error = fmt.Sprintf("No associated projects found for organization '%s'\n", organizationName)
-			r := output.RenderOutput(output.Table{Data: []output.Data{[]string{}}}, outputOptions)
-			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
+			handleNilResults("No associated projects found for organization '%s'\n", cmd, organizationName)
 			return nil
 		}
 
@@ -1012,9 +1008,7 @@ var listOrganizationGroupsCmd = &cobra.Command{
 			return err
 		}
 		if len(*orgGroups) == 0 {
-			outputOptions.Error = fmt.Sprintf("No associated groups found for organization '%s'\n", organizationName)
-			r := output.RenderOutput(output.Table{Data: []output.Data{[]string{}}}, outputOptions)
-			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
+			handleNilResults("No associated groups found for organization '%s'\n", cmd, organizationName)
 			return nil
 		}
 
@@ -1074,9 +1068,7 @@ var listOrganizationDeployTargetsCmd = &cobra.Command{
 			return err
 		}
 		if len(*deployTargets) == 0 {
-			outputOptions.Error = fmt.Sprintf("No associated deploy targets found for organization '%s'\n", organizationName)
-			r := output.RenderOutput(output.Table{Data: []output.Data{[]string{}}}, outputOptions)
-			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
+			handleNilResults("No associated deploy targets found for organization '%s'\n", cmd, organizationName)
 			return nil
 		}
 
@@ -1188,9 +1180,7 @@ var listOrganizationAdminsCmd = &cobra.Command{
 			return err
 		}
 		if len(*users) == 0 {
-			outputOptions.Error = fmt.Sprintf("No associated users found for organization '%s'\n", organizationName)
-			r := output.RenderOutput(output.Table{Data: []output.Data{[]string{}}}, outputOptions)
-			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
+			handleNilResults("No associated users found for organization '%s'\n", cmd, organizationName)
 			return nil
 		}
 		data := []output.Data{}

--- a/cmd/notificationsemail.go
+++ b/cmd/notificationsemail.go
@@ -173,9 +173,9 @@ var listProjectEmailsCmd = &cobra.Command{
 			return err
 		}
 		if len(result.Name) == 0 {
-			outputOptions.Error = fmt.Sprintf("No project found for '%s'\n", cmdProjectName)
+			return handleNilResults("No project found for '%s'\n", cmd, cmdProjectName)
 		} else if len(result.Notifications.Email) == 0 {
-			outputOptions.Error = fmt.Sprintf("No email notificatons found for project: '%s'\n", cmdProjectName)
+			return handleNilResults("No email notificatons found for project: '%s'\n", cmd, cmdProjectName)
 		}
 
 		data := []output.Data{}
@@ -268,15 +268,24 @@ var deleteProjectEmailNotificationCmd = &cobra.Command{
 		if err := requiredInputCheck("Project name", cmdProjectName, "Notification name", name); err != nil {
 			return err
 		}
+
+		current := lagoonCLIConfig.Current
+		token := lagoonCLIConfig.Lagoons[current].Token
+		lc := lclient.New(
+			lagoonCLIConfig.Lagoons[current].GraphQL,
+			lagoonCLIVersion,
+			lagoonCLIConfig.Lagoons[current].Version,
+			&token,
+			debug)
+
+		project, err := lagoon.GetProjectByName(context.TODO(), cmdProjectName, lc)
+		if err != nil {
+			return err
+		}
+		if project.Name == "" {
+			return handleNilResults("No project found for '%s'\n", cmd, cmdProjectName)
+		}
 		if yesNo(fmt.Sprintf("You are attempting to delete email notification '%s' from project '%s', are you sure?", name, cmdProjectName)) {
-			current := lagoonCLIConfig.Current
-			token := lagoonCLIConfig.Lagoons[current].Token
-			lc := lclient.New(
-				lagoonCLIConfig.Lagoons[current].GraphQL,
-				lagoonCLIVersion,
-				lagoonCLIConfig.Lagoons[current].Version,
-				&token,
-				debug)
 			notification := &schema.RemoveNotificationFromProjectInput{
 				NotificationType: schema.EmailNotification,
 				NotificationName: name,
@@ -315,6 +324,7 @@ var deleteEmailNotificationCmd = &cobra.Command{
 		if err := requiredInputCheck("Notification name", name); err != nil {
 			return err
 		}
+		// Todo: Verify notifcation name exists - requires #PR https://github.com/uselagoon/lagoon/pull/3740
 		if yesNo(fmt.Sprintf("You are attempting to delete email notification '%s', are you sure?", name)) {
 			current := lagoonCLIConfig.Current
 			token := lagoonCLIConfig.Lagoons[current].Token

--- a/cmd/notificationsslack.go
+++ b/cmd/notificationsslack.go
@@ -180,9 +180,9 @@ var listProjectSlacksCmd = &cobra.Command{
 			return err
 		}
 		if len(result.Name) == 0 {
-			outputOptions.Error = fmt.Sprintf("No project found for '%s'\n", cmdProjectName)
+			return handleNilResults("No project found for '%s'\n", cmd, cmdProjectName)
 		} else if len(result.Notifications.Slack) == 0 {
-			outputOptions.Error = fmt.Sprintf("No slack notificatons found for project: '%s'\n", cmdProjectName)
+			return handleNilResults("No slack notificatons found for project: '%s'\n", cmd, cmdProjectName)
 		}
 
 		data := []output.Data{}
@@ -279,15 +279,25 @@ var deleteProjectSlackNotificationCmd = &cobra.Command{
 		if err := requiredInputCheck("Project name", cmdProjectName, "Notification name", name); err != nil {
 			return err
 		}
+
+		current := lagoonCLIConfig.Current
+		token := lagoonCLIConfig.Lagoons[current].Token
+		lc := lclient.New(
+			lagoonCLIConfig.Lagoons[current].GraphQL,
+			lagoonCLIVersion,
+			lagoonCLIConfig.Lagoons[current].Version,
+			&token,
+			debug)
+
+		project, err := lagoon.GetProjectByName(context.TODO(), cmdProjectName, lc)
+		if err != nil {
+			return err
+		}
+		if project.Name == "" {
+			return handleNilResults("No project found for '%s'\n", cmd, cmdProjectName)
+		}
+
 		if yesNo(fmt.Sprintf("You are attempting to delete Slack notification '%s' from project '%s', are you sure?", name, cmdProjectName)) {
-			current := lagoonCLIConfig.Current
-			token := lagoonCLIConfig.Lagoons[current].Token
-			lc := lclient.New(
-				lagoonCLIConfig.Lagoons[current].GraphQL,
-				lagoonCLIVersion,
-				lagoonCLIConfig.Lagoons[current].Version,
-				&token,
-				debug)
 			notification := &schema.RemoveNotificationFromProjectInput{
 				NotificationType: schema.SlackNotification,
 				NotificationName: name,
@@ -326,6 +336,7 @@ var deleteSlackNotificationCmd = &cobra.Command{
 		if err := requiredInputCheck("Notification name", name); err != nil {
 			return err
 		}
+		// Todo: Verify notifcation name exists - requires #PR https://github.com/uselagoon/lagoon/pull/3740
 		if yesNo(fmt.Sprintf("You are attempting to delete Slack notification '%s', are you sure?", name)) {
 			current := lagoonCLIConfig.Current
 			token := lagoonCLIConfig.Lagoons[current].Token

--- a/cmd/notificationsteams.go
+++ b/cmd/notificationsteams.go
@@ -173,9 +173,9 @@ var listProjectMicrosoftTeamsCmd = &cobra.Command{
 			return err
 		}
 		if len(result.Name) == 0 {
-			outputOptions.Error = fmt.Sprintf("No project found for '%s'\n", cmdProjectName)
+			return handleNilResults("No project found for '%s'\n", cmd, cmdProjectName)
 		} else if len(result.Notifications.MicrosoftTeams) == 0 {
-			outputOptions.Error = fmt.Sprintf("No microsoft teams notificatons found for project: '%s'\n", cmdProjectName)
+			return handleNilResults("No microsoft teams notificatons found for project: '%s'\n", cmd, cmdProjectName)
 		}
 
 		data := []output.Data{}
@@ -268,15 +268,25 @@ var deleteProjectMicrosoftTeamsNotificationCmd = &cobra.Command{
 		if err := requiredInputCheck("Project name", cmdProjectName, "Notification name", name); err != nil {
 			return err
 		}
+
+		current := lagoonCLIConfig.Current
+		token := lagoonCLIConfig.Lagoons[current].Token
+		lc := lclient.New(
+			lagoonCLIConfig.Lagoons[current].GraphQL,
+			lagoonCLIVersion,
+			lagoonCLIConfig.Lagoons[current].Version,
+			&token,
+			debug)
+
+		project, err := lagoon.GetProjectByName(context.TODO(), cmdProjectName, lc)
+		if err != nil {
+			return err
+		}
+		if project.Name == "" {
+			return handleNilResults("No project found for '%s'\n", cmd, cmdProjectName)
+		}
+
 		if yesNo(fmt.Sprintf("You are attempting to delete Microsoft Teams notification '%s' from project '%s', are you sure?", name, cmdProjectName)) {
-			current := lagoonCLIConfig.Current
-			token := lagoonCLIConfig.Lagoons[current].Token
-			lc := lclient.New(
-				lagoonCLIConfig.Lagoons[current].GraphQL,
-				lagoonCLIVersion,
-				lagoonCLIConfig.Lagoons[current].Version,
-				&token,
-				debug)
 			notification := &schema.RemoveNotificationFromProjectInput{
 				NotificationType: schema.MicrosoftTeamsNotification,
 				NotificationName: name,
@@ -315,6 +325,7 @@ var deleteMicrosoftTeamsNotificationCmd = &cobra.Command{
 		if err := requiredInputCheck("Notification name", name); err != nil {
 			return err
 		}
+		// Todo: Verify notifcation name exists - requires #PR https://github.com/uselagoon/lagoon/pull/3740
 		if yesNo(fmt.Sprintf("You are attempting to delete Microsoft Teams notification '%s', are you sure?", name)) {
 			current := lagoonCLIConfig.Current
 			token := lagoonCLIConfig.Lagoons[current].Token

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -696,6 +696,10 @@ var removeProjectFromOrganizationCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		if project.Name == "" {
+			handleNilResults("No project found for '%s'\n", cmd, cmdProjectName)
+			return nil
+		}
 		organization, err := lagoon.GetOrganizationByName(context.TODO(), organizationName, lc)
 		if err != nil {
 			return err

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -398,9 +398,7 @@ var updateProjectCmd = &cobra.Command{
 			return err
 		}
 		if project.Name == "" {
-			outputOptions.Error = fmt.Sprintf("Project '%s' not found\n", cmdProjectName)
-			output.RenderError(outputOptions.Error, outputOptions)
-			return nil
+			return handleNilResults("Project '%s' not found\n", cmd, cmdProjectName)
 		}
 		projectUpdate, err := lagoon.UpdateProject(context.TODO(), int(project.ID), projectPatch, lc)
 		if err != nil {
@@ -460,9 +458,9 @@ var listProjectByMetadata = &cobra.Command{
 		}
 		if len(*projects) == 0 {
 			if value != "" {
-				outputOptions.Error = fmt.Sprintf("No projects found with metadata key '%s' and value '%s'\n", key, value)
+				return handleNilResults("No projects found with metadata key '%s' and value '%s'\n", cmd, key, value)
 			}
-			outputOptions.Error = fmt.Sprintf("No projects found with metadata key '%s'\n", key)
+			return handleNilResults("No projects found with metadata key '%s'\n", cmd, key)
 		}
 		data := []output.Data{}
 		for _, project := range *projects {
@@ -520,7 +518,7 @@ var getProjectMetadata = &cobra.Command{
 			return err
 		}
 		if len(project.Metadata) == 0 {
-			outputOptions.Error = fmt.Sprintf("There is no metadata for project '%s'\n", cmdProjectName)
+			return handleNilResults("There is no metadata for project '%s'\n", cmd, cmdProjectName)
 		}
 		data := []output.Data{}
 		for metaKey, metaVal := range project.Metadata {
@@ -697,8 +695,7 @@ var removeProjectFromOrganizationCmd = &cobra.Command{
 			return err
 		}
 		if project.Name == "" {
-			handleNilResults("No project found for '%s'\n", cmd, cmdProjectName)
-			return nil
+			return handleNilResults("No project found for '%s'\n", cmd, cmdProjectName)
 		}
 		organization, err := lagoon.GetOrganizationByName(context.TODO(), organizationName, lc)
 		if err != nil {

--- a/cmd/shared.go
+++ b/cmd/shared.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/spf13/cobra"
 	"os"
 	"strings"
 
@@ -106,4 +107,11 @@ func requiredInputCheck(fieldsAndValues ...string) error {
 		}
 	}
 	return nil
+}
+
+// Outputs the message in a way that can be captured by testing
+func handleNilResults(message string, cmd *cobra.Command, fields ...interface{}) {
+	outputOptions.Error = fmt.Sprintf(message, fields...)
+	r := output.RenderOutput(output.Table{Data: []output.Data{[]string{}}}, outputOptions)
+	fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 }

--- a/cmd/shared.go
+++ b/cmd/shared.go
@@ -110,8 +110,9 @@ func requiredInputCheck(fieldsAndValues ...string) error {
 }
 
 // Outputs the message in a way that can be captured by testing
-func handleNilResults(message string, cmd *cobra.Command, fields ...interface{}) {
+func handleNilResults(message string, cmd *cobra.Command, fields ...interface{}) error {
 	outputOptions.Error = fmt.Sprintf(message, fields...)
 	r := output.RenderOutput(output.Table{Data: []output.Data{[]string{}}}, outputOptions)
 	fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
+	return nil
 }

--- a/cmd/users.go
+++ b/cmd/users.go
@@ -407,8 +407,7 @@ var getUserKeysCmd = &cobra.Command{
 			return err
 		}
 		if len(userKeys.SSHKeys) == 0 {
-			output.RenderInfo(fmt.Sprintf("There are no SSH keys for user '%s'\n", strings.ToLower(userEmail)), outputOptions)
-			return nil
+			return handleNilResults("There are no SSH keys for user '%s'\n", cmd, strings.ToLower(userEmail))
 		}
 
 		data := []output.Data{}
@@ -475,7 +474,7 @@ var getAllUserKeysCmd = &cobra.Command{
 			}
 		}
 		if len(userGroups) == 0 {
-			outputOptions.Error = fmt.Sprintf("No SSH keys for group '%s'\n", groupName)
+			return handleNilResults("There are no SSH keys for users in group '%s'\n", cmd, groupName)
 		}
 		var data []output.Data
 		for _, userData := range userGroups {

--- a/cmd/variables.go
+++ b/cmd/variables.go
@@ -91,7 +91,7 @@ var addVariableCmd = &cobra.Command{
 			}, outputOptions)
 			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 		} else {
-			output.RenderInfo(fmt.Sprintf("variable %s remained unchanged\n", varName), outputOptions)
+			return handleNilResults("Variable '%s' remained unchanged\n", cmd, varName)
 		}
 		return nil
 	},


### PR DESCRIPTION
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

A number of commands don't have validation on key flags which results in errors & nil results. 

This adds additional validation & a helper func to better handle nil results. Also adds newlines where relevant due to the change in output in PR https://github.com/uselagoon/lagoon-cli/pull/364 

A couple examples:

Nil results
![image](https://github.com/user-attachments/assets/70d988a9-66a2-499b-88a0-ac072eef4f08)

Error due to non-existent project being passed - `lagoon delete org-p -p invalidProject --organization-name lagoon-demo-organization` (More an api issue, but simple enough to handle here)
![image](https://github.com/user-attachments/assets/1f15992b-e147-42e2-b6fc-7ed3f88abae1)
