### PR TITLE
fix: unable to skip strict host key checking when known_hosts file is missing

### DIFF
--- a/pkg/lagoon/ssh/main.go
+++ b/pkg/lagoon/ssh/main.go
@@ -163,13 +163,13 @@ Add correct host key in %s to get rid of this message`
 
 // add interactive known hosts to reduce confusion with host key errors
 func InteractiveKnownHosts(userPath, host string, ignorehost, accept bool) (ssh.HostKeyCallback, []string, error) {
+	if ignorehost {
+		// if ignore provided, just skip the hostkey verifications
+		return ssh.InsecureIgnoreHostKey(), nil, nil
+	}
 	kh, err := knownhosts.NewDB(path.Join(userPath, ".ssh/known_hosts"))
 	if err != nil {
 		return nil, nil, fmt.Errorf("couldn't get ~/.ssh/known_hosts: %v", err)
-	}
-	if ignorehost {
-		// if ignore provided, just skip the hostkey verifications
-		return ssh.InsecureIgnoreHostKey(), kh.HostKeyAlgorithms(host), nil
 	}
 	// otherwise prompt or accept for the key if required
 	return ssh.HostKeyCallback(func(hostname string, remote net.Addr, key ssh.PublicKey) error {


### PR DESCRIPTION


 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [x] Affected Issues have been mentioned in the Closing issues section
- [x] Documentation has been written/updated
- [x] PR title is ready for inclusion in changelog

Automated tests for DDev are failing because their CI does not instantiate an environment with a `known_hosts` file. Even when adding the `--strict-host-key-checking no` flag, the cli still fails.

This PR skips the filesystem check when strict host key checking is disabled.

https://github.com/ddev/ddev/pull/6524