### PR TITLE
fix: return projectkey if reveal not provided

### DIFF
--- a/cmd/get.go
+++ b/cmd/get.go
@@ -339,8 +339,11 @@ var getProjectKeyCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		if projectKey.PublicKey == "" && projectKey.PrivateKey == "" {
+		if projectKey.PublicKey == "" {
 			return handleNilResults("No project-key for project '%s'\n", cmd, cmdProjectName)
+		}
+		if revealValue && projectKey.PrivateKey == "" {
+			return handleNilResults("No private-key for project '%s'\n", cmd, cmdProjectName)
 		}
 
 		projectKeys := []string{projectKey.PublicKey}


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

Just a small fix to only check if the `privateKey` is returned if reveal is provided. Since the query is requesting `projectKey` on project now, anyone with access to a project can view this, but only certain roles can view the `privateKey`.