### PR TITLE
feat: include buildstep in deployment get, list

### DIFF
--- a/docs/commands/lagoon_get_deployment.md
+++ b/docs/commands/lagoon_get_deployment.md
@@ -17,6 +17,7 @@ lagoon get deployment [flags]
   -h, --help          help for deployment
   -L, --logs          Show the build logs if available
   -N, --name string   The name of the deployment (eg, lagoon-build-abcdef)
+      --wide          Display additional information about deployments
 ```
 
 ### Options inherited from parent commands

--- a/docs/commands/lagoon_list_deployments.md
+++ b/docs/commands/lagoon_list_deployments.md
@@ -10,6 +10,7 @@ lagoon list deployments [flags]
 
 ```
   -h, --help   help for deployments
+      --wide   Display additional information about deployments
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

Update `get` and `list` deployments to include the `buildStep`. Move the fields `remoteId` and `created` fields into a new `--wide` flag to reduce the information displayed to only more relevant information.

Example of how this looks
```
$ lagoon list deployments -p example-project -e test
ID     	NAME               	STATUS  	BUILDSTEP                  	STARTED            	COMPLETED
234    	lagoon-build-j85815	complete	deployCompletedWithWarnings	2024-10-03 14:43:50	2024-10-03 14:47:05
233    	lagoon-build-q9h7a6	failed  	runningPostRolloutTasks    	2024-10-03 14:28:02	2024-10-03 14:31:48
232    	lagoon-build-lxec85	failed  	runningPostRolloutTasks    	2024-10-03 11:23:06	2024-10-03 11:30:20

$ lagoon list deployments -p example-project -e test --wide
ID     	NAME               	STATUS  	BUILDSTEP                  	STARTED            	COMPLETED          	CREATED            	REMOTEID
234    	lagoon-build-j85815	complete	deployCompletedWithWarnings	2024-10-03 14:43:50	2024-10-03 14:47:05	2024-10-03 14:43:49	010f5f74-0063-4ffc-94c2-62df2c7f4f0e
233    	lagoon-build-q9h7a6	failed  	runningPostRolloutTasks    	2024-10-03 14:28:02	2024-10-03 14:31:48	2024-10-03 14:28:01	f2562e43-026b-493e-889b-7e1ed2cada61
232    	lagoon-build-lxec85	failed  	runningPostRolloutTasks    	2024-10-03 11:23:06	2024-10-03 11:30:20	2024-10-03 11:23:06	aabf6436-a843-4eb6-8953-70d4515f3982

$ lagoon get deployment -p example-project -e test --name lagoon-build-q9h7a6
ID     	NAME               	STATUS	BUILDSTEP              	STARTED            	COMPLETED
233    	lagoon-build-q9h7a6	failed	runningPostRolloutTasks	2024-10-03 14:28:02	2024-10-03 14:31:48

$ lagoon get deployment -p example-project -e test --name lagoon-build-q9h7a6 --wide
ID     	NAME               	STATUS	BUILDSTEP              	STARTED            	COMPLETED          	CREATED            	REMOTEID
233    	lagoon-build-q9h7a6	failed	runningPostRolloutTasks	2024-10-03 14:28:02	2024-10-03 14:31:48	2024-10-03 14:28:01	f2562e43-026b-493e-889b-7e1ed2cada61
```

# Closing issues

closes https://github.com/uselagoon/lagoon/issues/3819