### PR TITLE
refactor: remove getminimalprojectbyname where possible

### DIFF
--- a/cmd/deploytargetconfig.go
+++ b/cmd/deploytargetconfig.go
@@ -57,13 +57,8 @@ var addDeployTargetConfigCmd = &cobra.Command{
 			&token,
 			debug)
 
-		project, err := lagoon.GetMinimalProjectByName(context.TODO(), cmdProjectName, lc)
-		if err != nil {
-			return err
-		}
 		addDeployTargetConfig := &schema.AddDeployTargetConfigInput{
-			Project: project.ID,
-			Weight:  weight,
+			Weight: weight,
 		}
 		if branches != "" {
 			addDeployTargetConfig.Branches = branches
@@ -75,9 +70,9 @@ var addDeployTargetConfigCmd = &cobra.Command{
 			addDeployTargetConfig.DeployTarget = deploytarget
 		}
 		if yesNo(fmt.Sprintf("You are attempting to add a deploytarget configuration to project '%s', are you sure?", cmdProjectName)) {
-			deployTargetConfig, err := lagoon.AddDeployTargetConfiguration(context.TODO(), addDeployTargetConfig, lc)
+			deployTargetConfig, err := lagoon.AddDeployTargetConfigurationByProjectName(context.TODO(), cmdProjectName, addDeployTargetConfig, lc)
 			if err != nil {
-				return err
+				return fmt.Errorf("%v: check if the project exists", err.Error())
 			}
 			data := []output.Data{}
 			data = append(data, []string{
@@ -234,18 +229,10 @@ var deleteDeployTargetConfigCmd = &cobra.Command{
 			&token,
 			debug)
 
-		project, err := lagoon.GetMinimalProjectByName(context.TODO(), cmdProjectName, lc)
-		if err != nil {
-			return err
-		}
-		if project.Name == "" {
-			return handleNilResults("Project '%s' not found\n", cmd, cmdProjectName)
-		}
-
 		if yesNo(fmt.Sprintf("You are attempting to delete deploytarget configuration with id '%d' from project '%s', are you sure?", id, cmdProjectName)) {
-			result, err := lagoon.DeleteDeployTargetConfiguration(context.TODO(), int(id), int(project.ID), lc)
+			result, err := lagoon.DeleteDeployTargetConfigurationByIDAndProjectName(context.TODO(), id, cmdProjectName, lc)
 			if err != nil {
-				return err
+				return fmt.Errorf("%v: check if the project exists", err.Error())
 			}
 			resultData := output.Result{
 				Result: result.DeleteDeployTargetConfig,
@@ -284,16 +271,9 @@ var listDeployTargetConfigsCmd = &cobra.Command{
 			&token,
 			debug)
 
-		project, err := lagoon.GetMinimalProjectByName(context.TODO(), cmdProjectName, lc)
+		deployTargetConfigs, err := lagoon.GetDeployTargetConfigsByProjectName(context.TODO(), cmdProjectName, lc)
 		if err != nil {
-			return err
-		}
-		if project.Name == "" {
-			return handleNilResults("Project '%s' not found\n", cmd, cmdProjectName)
-		}
-		deployTargetConfigs, err := lagoon.GetDeployTargetConfigs(context.TODO(), int(project.ID), lc)
-		if err != nil {
-			return err
+			return fmt.Errorf("%v: check if the project exists", err.Error())
 		}
 		if len(*deployTargetConfigs) == 0 {
 			return handleNilResults("No deploytarget-configs for project '%s'\n", cmd, cmdProjectName)

--- a/cmd/environment.go
+++ b/cmd/environment.go
@@ -118,19 +118,10 @@ var updateEnvironmentCmd = &cobra.Command{
 			lagoonCLIConfig.Lagoons[current].Version,
 			&token,
 			debug)
-		project, err := lagoon.GetMinimalProjectByName(context.TODO(), cmdProjectName, lc)
-		if project.Name == "" {
-			err = fmt.Errorf("project not found")
-		}
+
+		environment, err := lagoon.GetEnvironmentByNameAndProjectName(context.TODO(), cmdProjectEnvironment, cmdProjectName, lc)
 		if err != nil {
-			return err
-		}
-		environment, err := lagoon.GetEnvironmentByName(context.TODO(), cmdProjectEnvironment, project.ID, lc)
-		if environment.Name == "" {
-			err = fmt.Errorf("environment not found")
-		}
-		if err != nil {
-			return err
+			return fmt.Errorf("%v: check if the project or environment exists", err.Error())
 		}
 
 		environmentFlags := schema.UpdateEnvironmentPatchInput{
@@ -202,16 +193,9 @@ var listBackupsCmd = &cobra.Command{
 			&token,
 			debug)
 
-		project, err := lagoon.GetMinimalProjectByName(context.TODO(), cmdProjectName, lc)
+		backupsResult, err := lagoon.GetBackupsForEnvironmentByNameAndProjectName(context.TODO(), cmdProjectEnvironment, cmdProjectName, lc)
 		if err != nil {
-			return err
-		}
-		if project.Name == "" {
-			return handleNilResults("No project found for '%s'\n", cmd, cmdProjectName)
-		}
-		backupsResult, err := lagoon.GetBackupsForEnvironmentByName(context.TODO(), cmdProjectEnvironment, project.ID, lc)
-		if err != nil {
-			return err
+			return fmt.Errorf("%v: check if the project or environment exists", err.Error())
 		}
 		data := []output.Data{}
 		for _, backup := range backupsResult.Backups {
@@ -276,13 +260,9 @@ This returns a direct URL to the backup, this is a signed download link with a l
 			&token,
 			debug)
 
-		project, err := lagoon.GetMinimalProjectByName(context.TODO(), cmdProjectName, lc)
+		backupsResult, err := lagoon.GetBackupsForEnvironmentByNameAndProjectName(context.TODO(), cmdProjectEnvironment, cmdProjectName, lc)
 		if err != nil {
-			return err
-		}
-		backupsResult, err := lagoon.GetBackupsForEnvironmentByName(context.TODO(), cmdProjectEnvironment, project.ID, lc)
-		if err != nil {
-			return err
+			return fmt.Errorf("%v: check if the project or environment exists", err.Error())
 		}
 		status := ""
 		for _, backup := range backupsResult.Backups {

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -327,17 +327,9 @@ var getProjectKeyCmd = &cobra.Command{
 			&token,
 			debug)
 
-		project, err := lagoon.GetMinimalProjectByName(context.TODO(), cmdProjectName, lc)
-		if err != nil {
-			return err
-		}
-		if project.Name == "" {
-			return handleNilResults("No project found for '%s'\n", cmd, cmdProjectName)
-		}
-
 		projectKey, err := lagoon.GetProjectKeyByName(context.TODO(), cmdProjectName, revealValue, lc)
 		if err != nil {
-			return err
+			return fmt.Errorf("%v: check if the project exists", err.Error())
 		}
 		if projectKey.PublicKey == "" {
 			return handleNilResults("No project-key for project '%s'\n", cmd, cmdProjectName)

--- a/cmd/groups.go
+++ b/cmd/groups.go
@@ -209,16 +209,9 @@ var addProjectToGroupCmd = &cobra.Command{
 			&token,
 			debug)
 
-		project, err := lagoon.GetMinimalProjectByName(context.TODO(), cmdProjectName, lc)
-		if err != nil {
-			return err
-		}
-		if len(project.Name) == 0 {
-			return handleNilResults("Project '%s' not found\n", cmd, cmdProjectName)
-		}
 		_, err = lagoon.AddProjectToGroup(context.TODO(), projectGroup, lc)
 		if err != nil {
-			return err
+			return fmt.Errorf("%v: check if the project or group exists", err.Error())
 		}
 
 		resultData := output.Result{
@@ -328,18 +321,10 @@ var deleteProjectFromGroupCmd = &cobra.Command{
 			&token,
 			debug)
 
-		project, err := lagoon.GetMinimalProjectByName(context.TODO(), cmdProjectName, lc)
-		if err != nil {
-			return err
-		}
-		if len(project.Name) == 0 {
-			return handleNilResults("Project '%s' not found\n", cmd, cmdProjectName)
-		}
-
 		if yesNo(fmt.Sprintf("You are attempting to delete project '%s' from group '%s', are you sure?", projectGroup.Project.Name, projectGroup.Groups[0].Name)) {
 			_, err = lagoon.RemoveGroupsFromProject(context.TODO(), projectGroup, lc)
 			if err != nil {
-				return err
+				return fmt.Errorf("%v: check if the project or group exists", err.Error())
 			}
 
 			resultData := output.Result{

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -494,17 +494,9 @@ var listDeploymentsCmd = &cobra.Command{
 			&token,
 			debug)
 
-		project, err := lagoon.GetMinimalProjectByName(context.TODO(), cmdProjectName, lc)
+		deployments, err := lagoon.GetDeploymentsByEnvironmentAndProjectName(context.TODO(), cmdProjectName, cmdProjectEnvironment, lc)
 		if err != nil {
-			return err
-		}
-		if project.Name == "" {
-			return handleNilResults("No project found for '%s'\n", cmd, cmdProjectName)
-		}
-
-		deployments, err := lagoon.GetDeploymentsByEnvironment(context.TODO(), project.ID, cmdProjectEnvironment, lc)
-		if err != nil {
-			return err
+			return fmt.Errorf("%v: check if the project or environment exists", err.Error())
 		}
 
 		data := []output.Data{}
@@ -558,17 +550,9 @@ var listTasksCmd = &cobra.Command{
 			&token,
 			debug)
 
-		project, err := lagoon.GetMinimalProjectByName(context.TODO(), cmdProjectName, lc)
+		tasks, err := lagoon.GetTasksByEnvironmentAndProjectName(context.TODO(), cmdProjectName, cmdProjectEnvironment, lc)
 		if err != nil {
-			return err
-		}
-		if project.Name == "" {
-			return handleNilResults("No project found for '%s'\n", cmd, cmdProjectName)
-		}
-
-		tasks, err := lagoon.GetTasksByEnvironment(context.TODO(), project.ID, cmdProjectEnvironment, lc)
-		if err != nil {
-			return err
+			return fmt.Errorf("%v: check if the project or environment exists", err.Error())
 		}
 
 		data := []output.Data{}
@@ -796,16 +780,9 @@ var listInvokableTasks = &cobra.Command{
 			&token,
 			debug)
 
-		project, err := lagoon.GetMinimalProjectByName(context.TODO(), cmdProjectName, lc)
+		tasks, err := lagoon.GetInvokableAdvancedTaskDefinitionsByEnvironmentAndProjectName(context.TODO(), cmdProjectName, cmdProjectEnvironment, lc)
 		if err != nil {
-			return err
-		}
-		if project.Name == "" {
-			return handleNilResults("No project found for '%s'\n", cmd, cmdProjectName)
-		}
-		tasks, err := lagoon.GetInvokableAdvancedTaskDefinitionsByEnvironment(context.TODO(), project.ID, cmdProjectEnvironment, lc)
-		if err != nil {
-			return err
+			return fmt.Errorf("%v: check if the project or environment exists", err.Error())
 		}
 
 		data := []output.Data{}

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -393,16 +393,9 @@ var updateProjectCmd = &cobra.Command{
 			}
 		}
 
-		project, err := lagoon.GetMinimalProjectByName(context.TODO(), cmdProjectName, lc)
+		projectUpdate, err := lagoon.UpdateProjectByName(context.TODO(), cmdProjectName, projectPatch, lc)
 		if err != nil {
-			return err
-		}
-		if project.Name == "" {
-			return handleNilResults("Project '%s' not found\n", cmd, cmdProjectName)
-		}
-		projectUpdate, err := lagoon.UpdateProject(context.TODO(), int(project.ID), projectPatch, lc)
-		if err != nil {
-			return err
+			return fmt.Errorf("%v: check if the project exists", err.Error())
 		}
 
 		resultData := output.Result{
@@ -573,13 +566,10 @@ var updateProjectMetadata = &cobra.Command{
 				lagoonCLIConfig.Lagoons[current].Version,
 				&token,
 				debug)
-			project, err := lagoon.GetMinimalProjectByName(context.TODO(), cmdProjectName, lc)
+
+			projectResult, err := lagoon.UpdateProjectMetadataByName(context.TODO(), cmdProjectName, key, value, lc)
 			if err != nil {
-				return err
-			}
-			projectResult, err := lagoon.UpdateProjectMetadata(context.TODO(), int(project.ID), key, value, lc)
-			if err != nil {
-				return err
+				return fmt.Errorf("%v: check if the project exists", err.Error())
 			}
 			data := []output.Data{}
 			metaData, _ := json.Marshal(projectResult.Metadata)
@@ -630,11 +620,8 @@ var deleteProjectMetadataByKey = &cobra.Command{
 				lagoonCLIConfig.Lagoons[current].Version,
 				&token,
 				debug)
-			project, err := lagoon.GetMinimalProjectByName(context.TODO(), cmdProjectName, lc)
-			if err != nil {
-				return err
-			}
-			projectResult, err := lagoon.RemoveProjectMetadataByKey(context.TODO(), int(project.ID), key, lc)
+
+			projectResult, err := lagoon.RemoveProjectMetadataByKeyByName(context.TODO(), cmdProjectName, key, lc)
 			if err != nil {
 				return err
 			}
@@ -690,6 +677,7 @@ var removeProjectFromOrganizationCmd = &cobra.Command{
 			&token,
 			debug)
 
+		// this can stay for now as `removeProjectFromOrganization` is platform only scoped
 		project, err := lagoon.GetMinimalProjectByName(context.TODO(), cmdProjectName, lc)
 		if err != nil {
 			return err

--- a/cmd/tasks.go
+++ b/cmd/tasks.go
@@ -149,11 +149,7 @@ var runDrushArchiveDump = &cobra.Command{
 			return err
 		}
 
-		project, err := lagoon.GetMinimalProjectByName(context.TODO(), cmdProjectName, lc)
-		if err != nil {
-			return err
-		}
-		environment, err := lagoon.GetEnvironmentByName(context.TODO(), cmdProjectEnvironment, project.ID, lc)
+		environment, err := lagoon.GetEnvironmentByNameAndProjectName(context.TODO(), cmdProjectEnvironment, cmdProjectName, lc)
 		if err != nil {
 			return err
 		}
@@ -218,11 +214,7 @@ var runDrushSQLDump = &cobra.Command{
 			return err
 		}
 
-		project, err := lagoon.GetMinimalProjectByName(context.TODO(), cmdProjectName, lc)
-		if err != nil {
-			return err
-		}
-		environment, err := lagoon.GetEnvironmentByName(context.TODO(), cmdProjectEnvironment, project.ID, lc)
+		environment, err := lagoon.GetEnvironmentByNameAndProjectName(context.TODO(), cmdProjectEnvironment, cmdProjectName, lc)
 		if err != nil {
 			return err
 		}
@@ -287,11 +279,7 @@ var runDrushCacheClear = &cobra.Command{
 			return err
 		}
 
-		project, err := lagoon.GetMinimalProjectByName(context.TODO(), cmdProjectName, lc)
-		if err != nil {
-			return err
-		}
-		environment, err := lagoon.GetEnvironmentByName(context.TODO(), cmdProjectEnvironment, project.ID, lc)
+		environment, err := lagoon.GetEnvironmentByNameAndProjectName(context.TODO(), cmdProjectEnvironment, cmdProjectName, lc)
 		if err != nil {
 			return err
 		}
@@ -476,11 +464,7 @@ Path:
 			Command: taskCommand,
 			Service: taskService,
 		}
-		project, err := lagoon.GetMinimalProjectByName(context.TODO(), cmdProjectName, lc)
-		if err != nil {
-			return err
-		}
-		environment, err := lagoon.GetEnvironmentByName(context.TODO(), cmdProjectEnvironment, project.ID, lc)
+		environment, err := lagoon.GetEnvironmentByNameAndProjectName(context.TODO(), cmdProjectEnvironment, cmdProjectName, lc)
 		if err != nil {
 			return err
 		}

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.2
-	github.com/uselagoon/machinery v0.0.29
+	github.com/uselagoon/machinery v0.0.30
 	go.uber.org/mock v0.4.0
 	golang.org/x/crypto v0.26.0
 	golang.org/x/term v0.23.0

--- a/go.sum
+++ b/go.sum
@@ -66,8 +66,8 @@ github.com/stretchr/testify v1.7.4/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/uselagoon/machinery v0.0.29 h1:invFIPv1Z1xCt8/1ilbiNDuAEPrb+AUO21BnNG+CX8c=
-github.com/uselagoon/machinery v0.0.29/go.mod h1:X0qguIO9skumMhhT0ap5CKHulKgYzy3TiIn+xlwiFQc=
+github.com/uselagoon/machinery v0.0.30 h1:nmdDyeEfts+obg4x/uIzCbHcNqyOkJZL0dUkI0hli48=
+github.com/uselagoon/machinery v0.0.30/go.mod h1:RsHzIMOam3hiA4CKR12yANgzdTGy6tz4D19umjMzZyw=
 go.uber.org/mock v0.4.0 h1:VcM4ZOtdbR4f6VXfiOpwpVJDL6lCReaZ6mw31wqh7KU=
 go.uber.org/mock v0.4.0/go.mod h1:a6FSlNadKUHUa9IP5Vyt1zh4fC7uAwxMutEAscFbkZc=
 golang.org/x/crypto v0.26.0 h1:RrRspgV4mU+YwB4FYnuBoKsUapNIL5cohGAmSH3azsw=


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

Not all roles can use `GetMinimalProjectByName` due to the `openshift` lookup performed in that query. 

This uses changes in machinery to update the functions that used to require the project ID to now accept project name, this includes a minimal projectByName that just gets the project name and id now which will work for any role that has the permission to view the project. See https://github.com/uselagoon/machinery/pull/74 (now available in v0.0.30)