### PR TITLE
chore: bump go version to supported release

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/uselagoon/lagoon-cli
 
-go 1.21
+go 1.23.2
 
 require (
 	github.com/Masterminds/semver/v3 v3.2.1


### PR DESCRIPTION
This also fixes the syntax in the current go.mod, which is no longer
strictly legal (missing the patch version) and trips up CodeQL.

https://go.dev/doc/toolchain#version
