### PR TITLE
fix: remove errant space in ssh command with service

### DIFF
--- a/pkg/lagoon/ssh/main.go
+++ b/pkg/lagoon/ssh/main.go
@@ -83,7 +83,7 @@ func InteractiveSSH(lagoon map[string]string, sshService string, sshContainer st
 	}
 	var connString string
 	if sshService != "" {
-		connString = fmt.Sprintf("%s service=%s", connString, sshService)
+		connString = fmt.Sprintf("service=%s", sshService)
 	}
 	if sshContainer != "" && sshService != "" {
 		connString = fmt.Sprintf("%s container=%s", connString, sshContainer)


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

Removes an errant space in the `service=%s` section of a command when attempting to ssh to a service.
