### PR TITLE
fix: force token refresh with lagoon login

### DIFF
--- a/docs/commands/lagoon.md
+++ b/docs/commands/lagoon.md
@@ -45,7 +45,7 @@ lagoon [flags]
 * [lagoon import](lagoon_import.md)	 - Import a config from a yaml file
 * [lagoon kibana](lagoon_kibana.md)	 - Launch the kibana interface
 * [lagoon list](lagoon_list.md)	 - List projects, environments, deployments, variables or notifications
-* [lagoon login](lagoon_login.md)	 - Log into a Lagoon instance
+* [lagoon login](lagoon_login.md)	 - Login or refresh an authentication token
 * [lagoon logs](lagoon_logs.md)	 - Display logs for a service of an environment and project
 * [lagoon raw](lagoon_raw.md)	 - Run a custom query or mutation
 * [lagoon reset-password](lagoon_reset-password.md)	 - Send a password reset email

--- a/docs/commands/lagoon_login.md
+++ b/docs/commands/lagoon_login.md
@@ -1,6 +1,11 @@
 ## lagoon login
 
-Log into a Lagoon instance
+Login or refresh an authentication token
+
+### Synopsis
+
+Login or refresh an authentication token
+This can be used to clear out and force your CLI to refresh a token for a given context.
 
 ```
 lagoon login [flags]
@@ -9,7 +14,8 @@ lagoon login [flags]
 ### Options
 
 ```
-  -h, --help   help for login
+  -h, --help          help for login
+      --reset-token   clear the token before attempting to log in
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
 <!--
**IMPORTANT: Please provide enough information and context so that others can review your pull request:**
 -->

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog

This change forces the `lagoon login` command to refresh the token. Previously this command would only refresh a token if it was invalid, effectively doing nothing.

For users that use many keys, this can lead to problems where the token may be for another user that previously authenticated, but still had a valid token. With a user believing that `lagoon login` was clearing out the token.

This is addressed in #319, but that pull request has considerable changes that are breaking for users, so this pull request brings a version of that functionality to the current CLI format.