### PR TITLE
fix: Adds missing flags to variable update

### DIFF
--- a/cmd/variables.go
+++ b/cmd/variables.go
@@ -166,5 +166,8 @@ func init() {
 	addVariableCmd.Flags().StringP("name", "N", "", "Name of the variable to add")
 	addVariableCmd.Flags().StringP("value", "V", "", "Value of the variable to add")
 	addVariableCmd.Flags().StringP("scope", "S", "", "Scope of the variable[global, build, runtime, container_registry, internal_container_registry]")
+	updateVariableCmd.Flags().StringP("name", "N", "", "Name of the variable to add")
+	updateVariableCmd.Flags().StringP("value", "V", "", "Value of the variable to add")
+	updateVariableCmd.Flags().StringP("scope", "S", "", "Scope of the variable[global, build, runtime, container_registry, internal_container_registry]")
 	deleteVariableCmd.Flags().StringP("name", "N", "", "Name of the variable to delete")
 }

--- a/cmd/variables.go
+++ b/cmd/variables.go
@@ -166,8 +166,8 @@ func init() {
 	addVariableCmd.Flags().StringP("name", "N", "", "Name of the variable to add")
 	addVariableCmd.Flags().StringP("value", "V", "", "Value of the variable to add")
 	addVariableCmd.Flags().StringP("scope", "S", "", "Scope of the variable[global, build, runtime, container_registry, internal_container_registry]")
-	updateVariableCmd.Flags().StringP("name", "N", "", "Name of the variable to add")
-	updateVariableCmd.Flags().StringP("value", "V", "", "Value of the variable to add")
+	updateVariableCmd.Flags().StringP("name", "N", "", "Name of the variable to update")
+	updateVariableCmd.Flags().StringP("value", "V", "", "Value of the variable to update")
 	updateVariableCmd.Flags().StringP("scope", "S", "", "Scope of the variable[global, build, runtime, container_registry, internal_container_registry]")
 	deleteVariableCmd.Flags().StringP("name", "N", "", "Name of the variable to delete")
 }

--- a/docs/commands/lagoon_update_variable.md
+++ b/docs/commands/lagoon_update_variable.md
@@ -9,7 +9,10 @@ lagoon update variable [flags]
 ### Options
 
 ```
-  -h, --help   help for variable
+  -h, --help           help for variable
+  -N, --name string    Name of the variable to add
+  -S, --scope string   Scope of the variable[global, build, runtime, container_registry, internal_container_registry]
+  -V, --value string   Value of the variable to add
 ```
 
 ### Options inherited from parent commands

--- a/docs/commands/lagoon_update_variable.md
+++ b/docs/commands/lagoon_update_variable.md
@@ -10,9 +10,9 @@ lagoon update variable [flags]
 
 ```
   -h, --help           help for variable
-  -N, --name string    Name of the variable to add
+  -N, --name string    Name of the variable to update
   -S, --scope string   Scope of the variable[global, build, runtime, container_registry, internal_container_registry]
-  -V, --value string   Value of the variable to add
+  -V, --value string   Value of the variable to update
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
The 0.31.3 release introduced some refactoring of the add/update variable commands that inadvertently lead to flags not being attached to the variable update command. This PR reintroduces them.

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog
