### PR TITLE
fix: Always outputs stdout for running, non-interactive, shells

### DIFF
--- a/pkg/lagoon/ssh/main.go
+++ b/pkg/lagoon/ssh/main.go
@@ -146,12 +146,17 @@ func RunSSHCommand(lagoon map[string]string, sshService string, sshContainer str
 	}
 	var b bytes.Buffer
 	session.Stdout = &b
-
 	err = session.Run(connString + " " + command)
+
+	// if there's anything waiting in the buffer, display it (regardless of error state or not)
+	// it may, in error state, contain useful information.
+	if b.Len() > 0 {
+		fmt.Println(b.String())
+	}
+
 	if err != nil {
 		return err
 	}
-	fmt.Println(b.String())
 	return nil
 }
 

--- a/pkg/lagoon/ssh/main.go
+++ b/pkg/lagoon/ssh/main.go
@@ -146,17 +146,17 @@ func RunSSHCommand(lagoon map[string]string, sshService string, sshContainer str
 	}
 	var b bytes.Buffer
 	session.Stdout = &b
+	var e bytes.Buffer
+	session.Stderr = &e
 	err = session.Run(connString + " " + command)
 
-	// if there's anything waiting in the buffer, display it (regardless of error state or not)
-	// it may, in error state, contain useful information.
-	if b.Len() > 0 {
-		fmt.Println(b.String())
-	}
-
 	if err != nil {
+		fmt.Fprintf(os.Stderr, b.String())
+		fmt.Fprintf(os.Stderr, e.String())
 		return err
 	}
+	fmt.Fprintf(os.Stdout, b.String())
+	fmt.Fprintf(os.Stderr, e.String())
 	return nil
 }
 

--- a/pkg/lagoon/ssh/main.go
+++ b/pkg/lagoon/ssh/main.go
@@ -151,12 +151,12 @@ func RunSSHCommand(lagoon map[string]string, sshService string, sshContainer str
 	err = session.Run(connString + " " + command)
 
 	if err != nil {
-		fmt.Fprintf(os.Stderr, b.String())
-		fmt.Fprintf(os.Stderr, e.String())
+		os.Stderr.WriteString(b.String())
+		os.Stderr.WriteString(e.String())
 		return err
 	}
-	fmt.Fprintf(os.Stdout, b.String())
-	fmt.Fprintf(os.Stderr, e.String())
+	os.Stdout.WriteString(b.String())
+	os.Stderr.WriteString(e.String())
 	return nil
 }
 


### PR DESCRIPTION
With non-interactive ssh calls, the RunSSHCommand function was exiting with only an error returned, but not outputting anything that came back via stdout, as it would on successful calls.

This meant that we were losing some important information in the output. This PR simply ensures that if there _is_ data buffered from stdout, we're displaying in.

<!-- You can skip this if you're fixing a typo. -->
# General Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for inclusion in changelog


# Closing issues

closes #426 