### PR TITLE
chore: allow builder to set OS/ARCH

### DIFF
--- a/.github/workflows/lagoon-cli.yaml
+++ b/.github/workflows/lagoon-cli.yaml
@@ -75,14 +75,14 @@ jobs:
         uses: docker/setup-buildx-action@v3
       -
         name: Login to DockerHub
-        if: github.event_name != 'pull_request'
+        if: github.event.pull_request.head.repo.full_name == github.repository
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
         name: Login to GHCR
-        if: github.event_name != 'pull_request'
+        if: github.event.pull_request.head.repo.full_name == github.repository
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -95,6 +95,6 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           build-args: VERSION=${{ env.VERSION}}
-          push: ${{ github.event_name != 'pull_request' }}
+          push: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,6 @@ WORKDIR /go/src/github.com/uselagoon/lagoon-cli/
 COPY . .
 
 ARG VERSION
-ARG OS
-ENV OS=${OS:-linux}
-ARG ARCH
-ENV ARCH=${ARCH:-amd64}
 
 RUN apk update && apk add git
 


### PR DESCRIPTION
A multiarch build defines its own OS and ARCH - this PR ensures that the build is built as the correct architecture for the destination instead of falling back to linux/amd64