### PR TITLE
fix: inability to add ssh-key to new lagoon

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -27,7 +27,7 @@ type LagoonConfigFlags struct {
 	Token     string `json:"token,omitempty"`
 	UI        string `json:"ui,omitempty"`
 	Kibana    string `json:"kibana,omitempty"`
-	SSHKey    string `json:"sshkey,omitempty"`
+	SSHKey    string `json:"ssh-key,omitempty"`
 	SSHPortal bool   `json:"sshportal,omitempty"`
 }
 


### PR DESCRIPTION
# General Checklist

- [x] Affected Issues have been mentioned in the Closing issues section
- [x] Documentation has been written/updated
- [x] PR title is ready for inclusion in changelog

# Description

Currently, it is not possible to add to add an ssh-key to a new Lagoon instance using the following command:

```bash
lagoon config add \
        --force \
        --graphql URL \
        --ui URL \
        --hostname IP \
        --lagoon lagoon \
        --port 2020 \
        --ssh-key "/path/to/key"
```

This is due to a missing dash in the `LagoonConfigFlags`.




