### PR TITLE
simplify ssh conn string

### DIFF
--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -35,7 +35,7 @@ var sshEnvCmd = &cobra.Command{
 		// since ssh requires the `feature-branch` type name to be used as the ssh username
 		// run the environment through the makesafe and shorted functions that lagoon uses
 		environmentName := makeSafe(shortenEnvironment(cmdProjectName, cmdProjectEnvironment))
-		sshHost, sshPort, username, isPortal, err := getSSHHostPort(environmentName, debug)
+		sshHost, sshPort, username, _, err := getSSHHostPort(environmentName, debug)
 		if err != nil {
 			return fmt.Errorf("couldn't get SSH endpoint: %v", err)
 		}
@@ -60,7 +60,7 @@ var sshEnvCmd = &cobra.Command{
 			"sshkey":   privateKey,
 		}
 		if sshConnString {
-			fmt.Println(generateSSHConnectionString(sshConfig, sshService, sshContainer, isPortal))
+			fmt.Println(generateSSHConnectionString(sshConfig, sshService, sshContainer))
 		} else {
 			hkcb, hkalgo, err := lagoonssh.InteractiveKnownHosts(userPath, fmt.Sprintf("%s:%s", sshHost, sshPort), ignoreHostKey, acceptNewHostKey)
 			if err != nil {
@@ -107,7 +107,7 @@ func init() {
 }
 
 // generateSSHConnectionString .
-func generateSSHConnectionString(lagoon map[string]string, service string, container string, isPortal bool) string {
+func generateSSHConnectionString(lagoon map[string]string, service string, container string) string {
 	var connString string
 	if service != "" {
 		connString = "ssh -t"
@@ -116,9 +116,6 @@ func generateSSHConnectionString(lagoon map[string]string, service string, conta
 	}
 	if lagoon["sshKey"] != "" {
 		connString = fmt.Sprintf("%s -i %s", connString, lagoon["sshKey"])
-	}
-	if !isPortal {
-		connString = fmt.Sprintf("%s -o \"UserKnownHostsFile=/dev/null\" -o \"StrictHostKeyChecking=no\"", connString)
 	}
 	if lagoon["port"] != "22" {
 		connString = fmt.Sprintf("%s -p %v", connString, lagoon["port"])

--- a/cmd/ssh_test.go
+++ b/cmd/ssh_test.go
@@ -11,7 +11,6 @@ func Test_generateSSHConnectionString(t *testing.T) {
 		lagoon      map[string]string
 		service     string
 		container   string
-		isPortal    bool
 	}
 	tests := []struct {
 		name string
@@ -27,7 +26,7 @@ func Test_generateSSHConnectionString(t *testing.T) {
 					"username": "example-com-main",
 				},
 			},
-			want: `ssh -o "UserKnownHostsFile=/dev/null" -o "StrictHostKeyChecking=no" example-com-main@lagoon.example.com`,
+			want: `ssh example-com-main@lagoon.example.com`,
 		},
 		{
 			name: "test1 - service only, no container",
@@ -39,7 +38,7 @@ func Test_generateSSHConnectionString(t *testing.T) {
 				},
 				service: "cli",
 			},
-			want: `ssh -t -o "UserKnownHostsFile=/dev/null" -o "StrictHostKeyChecking=no" example-com-main@lagoon.example.com service=cli`,
+			want: `ssh -t example-com-main@lagoon.example.com service=cli`,
 		},
 		{
 			name: "test3 - service and container",
@@ -52,7 +51,7 @@ func Test_generateSSHConnectionString(t *testing.T) {
 				service:   "nginx-php",
 				container: "php",
 			},
-			want: `ssh -t -o "UserKnownHostsFile=/dev/null" -o "StrictHostKeyChecking=no" example-com-main@lagoon.example.com service=nginx-php container=php`,
+			want: `ssh -t example-com-main@lagoon.example.com service=nginx-php container=php`,
 		},
 		{
 			name: "test4",
@@ -66,7 +65,7 @@ func Test_generateSSHConnectionString(t *testing.T) {
 				service:   "cli",
 				container: "cli",
 			},
-			want: `ssh -t -i /home/user/.ssh/my-key -o "UserKnownHostsFile=/dev/null" -o "StrictHostKeyChecking=no" example-com-main@lagoon.example.com service=cli container=cli`,
+			want: `ssh -t -i /home/user/.ssh/my-key example-com-main@lagoon.example.com service=cli container=cli`,
 		},
 		{
 			name: "test5 - sshportal",
@@ -77,7 +76,6 @@ func Test_generateSSHConnectionString(t *testing.T) {
 					"username": "example-com-main",
 					"sshKey":   "/home/user/.ssh/my-key",
 				},
-				isPortal:  true,
 				service:   "cli",
 				container: "cli",
 			},
@@ -91,7 +89,6 @@ func Test_generateSSHConnectionString(t *testing.T) {
 					"port":     "22",
 					"username": "example-com-main",
 				},
-				isPortal:  true,
 				service:   "cli",
 				container: "cli",
 			},
@@ -105,7 +102,6 @@ func Test_generateSSHConnectionString(t *testing.T) {
 					"port":     "1122",
 					"username": "example-com-main",
 				},
-				isPortal: true,
 			},
 			want: `ssh -p 1122 example-com-main@lagoon.example.com`,
 		},
@@ -117,7 +113,6 @@ func Test_generateSSHConnectionString(t *testing.T) {
 					"port":     "1122",
 					"username": "example-com-main",
 				},
-				isPortal:  true,
 				service:   "cli",
 				container: "cli",
 			},
@@ -129,7 +124,7 @@ func Test_generateSSHConnectionString(t *testing.T) {
 			cmdProjectName = tt.args.project
 			cmdProjectEnvironment = tt.args.environment
 
-			if got := generateSSHConnectionString(tt.args.lagoon, tt.args.service, tt.args.container, tt.args.isPortal); got != tt.want {
+			if got := generateSSHConnectionString(tt.args.lagoon, tt.args.service, tt.args.container); got != tt.want {
 				t.Errorf("generateSSHConnectionString() = %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
This PR makes two changes to SSH connection string generation:

1. only use `-t` and `-p NN` when necessary, instead relying on ssh defaults.
   Before:

    ```
    $ lagoon ssh --conn-string -p my-demo -e master 
    ssh -t -p 22 my-demo-master@ssh.example.com

    $ lagoon ssh --conn-string -p my-demo -e master -s foo
    ssh -t -p 22 my-demo-master@ssh.example.com service=foo
    ```

   After:

    ```
    $ go run . ssh --conn-string -p my-demo -e master 
    ssh my-demo-master@ssh.example.com

    $ go run . ssh --conn-string -p my-demo -e master -s foo
    ssh -t my-demo-master@ssh.example.com service=foo
    ```

2. stop using `-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no` altogether, now that ssh-core has a static host key.