### PR TITLE
feat: improved error message for ssh on invalid environment name

### DIFF
--- a/cmd/shared.go
+++ b/cmd/shared.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"strconv"
@@ -10,8 +9,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/uselagoon/lagoon-cli/pkg/output"
-	lclient "github.com/uselagoon/machinery/api/lagoon/client"
-	"github.com/uselagoon/machinery/api/schema"
 )
 
 // config vars
@@ -128,32 +125,4 @@ func quotaCheck(quota int) string {
 		quotaRoute = "∞"
 	}
 	return quotaRoute
-}
-
-func environmentCheck(project string, environment string, debug bool) error {
-
-	current := lagoonCLIConfig.Current
-	token := lagoonCLIConfig.Lagoons[current].Token
-	lc := lclient.New(
-		lagoonCLIConfig.Lagoons[current].GraphQL,
-		lagoonCLIVersion,
-		lagoonCLIConfig.Lagoons[current].Version,
-		&token,
-		debug)
-	
-	var environments []schema.Environment	
-	err := lc.EnvironmentsByProjectName(context.TODO(), project, &environments)
-	if err != nil {
-		return err
-	}
-
-	names := make([]string, len(environments))
-	for i, e := range environments {
-		names[i] = e.AddEnvironmentInput.Name
-		if environment == names[i] {
-			return nil
-		}
-	}
-	
-	return fmt.Errorf("invalid environment for project %s: %s. Valid options are %s.\n", project, environment, strings.Join(names, ", "))
 }

--- a/cmd/shared.go
+++ b/cmd/shared.go
@@ -1,13 +1,17 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
-	"github.com/spf13/cobra"
 	"os"
 	"strconv"
 	"strings"
 
+	"github.com/spf13/cobra"
+
 	"github.com/uselagoon/lagoon-cli/pkg/output"
+	lclient "github.com/uselagoon/machinery/api/lagoon/client"
+	"github.com/uselagoon/machinery/api/schema"
 )
 
 // config vars
@@ -124,4 +128,32 @@ func quotaCheck(quota int) string {
 		quotaRoute = "∞"
 	}
 	return quotaRoute
+}
+
+func environmentCheck(project string, environment string, debug bool) error {
+
+	current := lagoonCLIConfig.Current
+	token := lagoonCLIConfig.Lagoons[current].Token
+	lc := lclient.New(
+		lagoonCLIConfig.Lagoons[current].GraphQL,
+		lagoonCLIVersion,
+		lagoonCLIConfig.Lagoons[current].Version,
+		&token,
+		debug)
+	
+	var environments []schema.Environment	
+	err := lc.EnvironmentsByProjectName(context.TODO(), project, &environments)
+	if err != nil {
+		return err
+	}
+
+	names := make([]string, len(environments))
+	for i, e := range environments {
+		names[i] = e.AddEnvironmentInput.Name
+		if environment == names[i] {
+			return nil
+		}
+	}
+	
+	return fmt.Errorf("invalid environment for project %s: %s. Valid options are %s.\n", project, environment, strings.Join(names, ", "))
 }

--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -27,10 +27,6 @@ var sshEnvCmd = &cobra.Command{
 		}
 		debug, err := cmd.Flags().GetBool("debug")
 		if err != nil {
-			return nil
-		}
-		err = environmentCheck(cmdProjectName, cmdProjectEnvironment, debug)
-		if err != nil {
 			return err
 		}
 		ignoreHostKey, acceptNewHostKey := lagoonssh.CheckStrictHostKey(strictHostKeyCheck)

--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -27,6 +27,10 @@ var sshEnvCmd = &cobra.Command{
 		}
 		debug, err := cmd.Flags().GetBool("debug")
 		if err != nil {
+			return nil
+		}
+		err = environmentCheck(cmdProjectName, cmdProjectEnvironment, debug)
+		if err != nil {
 			return err
 		}
 		ignoreHostKey, acceptNewHostKey := lagoonssh.CheckStrictHostKey(strictHostKeyCheck)


### PR DESCRIPTION
# Description

Closes #457.

 This PR introduces a new function `environmentCheck()` that checks a given environment name string belongs to a project, and if not, returns an error with valid options that the user has access to.

This PR only adds the check to the `ssh` command, but could be used for any command that mandates a project/environment input.