### PR TITLE
Implement build/deploy log support

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -3,13 +3,17 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"os"
 	"strconv"
+	"time"
 
+	"github.com/logrusorgru/aurora"
 	"github.com/uselagoon/lagoon-cli/pkg/output"
 
 	lclient "github.com/uselagoon/machinery/api/lagoon/client"
 
 	"github.com/spf13/cobra"
+	lagoonssh "github.com/uselagoon/lagoon-cli/pkg/lagoon/ssh"
 	"github.com/uselagoon/machinery/api/lagoon"
 	"github.com/uselagoon/machinery/api/schema"
 )
@@ -44,6 +48,10 @@ use 'lagoon deploy latest' instead`,
 			return err
 		}
 		returnData, err := cmd.Flags().GetBool("returndata")
+		if err != nil {
+			return err
+		}
+		follow, err := cmd.Flags().GetBool("follow")
 		if err != nil {
 			return err
 		}
@@ -85,6 +93,10 @@ use 'lagoon deploy latest' instead`,
 			resultData := output.Result{Result: result.DeployEnvironmentBranch}
 			r := output.RenderResult(resultData, outputOptions)
 			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
+
+			if follow {
+				return followDeployLogs(cmd, cmdProjectName, branch, resultData.Result, debug)
+			}
 		}
 		return nil
 	},
@@ -112,6 +124,10 @@ var deployPromoteCmd = &cobra.Command{
 			return err
 		}
 		returnData, err := cmd.Flags().GetBool("returndata")
+		if err != nil {
+			return err
+		}
+		follow, err := cmd.Flags().GetBool("follow")
 		if err != nil {
 			return err
 		}
@@ -150,6 +166,10 @@ var deployPromoteCmd = &cobra.Command{
 			resultData := output.Result{Result: result.DeployEnvironmentPromote}
 			r := output.RenderResult(resultData, outputOptions)
 			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
+
+			if follow {
+				return followDeployLogs(cmd, cmdProjectName, destinationEnvironment, resultData.Result, debug)
+			}
 		}
 		return nil
 	},
@@ -172,6 +192,10 @@ This environment should already exist in lagoon. It is analogous with the 'Deplo
 			return err
 		}
 		debug, err := cmd.Flags().GetBool("debug")
+		if err != nil {
+			return err
+		}
+		follow, err := cmd.Flags().GetBool("follow")
 		if err != nil {
 			return err
 		}
@@ -213,6 +237,10 @@ This environment should already exist in lagoon. It is analogous with the 'Deplo
 			resultData := output.Result{Result: result.DeployEnvironmentLatest}
 			r := output.RenderResult(resultData, outputOptions)
 			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
+
+			if follow {
+				return followDeployLogs(cmd, cmdProjectName, cmdProjectEnvironment, resultData.Result, debug)
+			}
 		}
 		return nil
 	},
@@ -273,6 +301,11 @@ This pullrequest may not already exist as an environment in lagoon.`,
 		if err != nil {
 			return err
 		}
+		follow, err := cmd.Flags().GetBool("follow")
+		if err != nil {
+			return err
+		}
+
 		if yesNo(fmt.Sprintf("You are attempting to deploy pull request '%v' for project '%s', are you sure?", prNumber, cmdProjectName)) {
 			current := lagoonCLIConfig.Current
 			token := lagoonCLIConfig.Lagoons[current].Token
@@ -302,6 +335,10 @@ This pullrequest may not already exist as an environment in lagoon.`,
 			resultData := output.Result{Result: result.DeployEnvironmentPullrequest}
 			r := output.RenderResult(resultData, outputOptions)
 			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
+
+			if follow {
+				return followDeployLogs(cmd, cmdProjectName, fmt.Sprintf("pr-%d", prNumber), resultData.Result, debug)
+			}
 		}
 		return nil
 	},
@@ -315,16 +352,19 @@ func init() {
 
 	const returnDataUsageText = "Returns the build name instead of success text"
 	deployLatestCmd.Flags().Bool("returndata", false, returnDataUsageText)
+	deployLatestCmd.Flags().Bool("follow", false, "Follow the deploy logs")
 	deployLatestCmd.Flags().StringArray("buildvar", []string{}, "Add one or more build variables to deployment (--buildvar KEY1=VALUE1 [--buildvar KEY2=VALUE2])")
 
 	deployBranchCmd.Flags().StringP("branch", "b", "", "Branch name to deploy")
 	deployBranchCmd.Flags().StringP("branch-ref", "r", "", "Branch ref to deploy")
 	deployBranchCmd.Flags().Bool("returndata", false, returnDataUsageText)
+	deployBranchCmd.Flags().Bool("follow", false, "Follow the deploy logs")
 	deployBranchCmd.Flags().StringArray("buildvar", []string{}, "Add one or more build variables to deployment (--buildvar KEY1=VALUE1 [--buildvar KEY2=VALUE2])")
 
 	deployPromoteCmd.Flags().StringP("destination", "d", "", "Destination environment name to create")
 	deployPromoteCmd.Flags().StringP("source", "s", "", "Source environment name to use as the base to deploy from")
 	deployPromoteCmd.Flags().Bool("returndata", false, returnDataUsageText)
+	deployPromoteCmd.Flags().Bool("follow", false, "Follow the deploy logs")
 	deployPromoteCmd.Flags().StringArray("buildvar", []string{}, "Add one or more build variables to deployment (--buildvar KEY1=VALUE1 [--buildvar KEY2=VALUE2])")
 
 	deployPullrequestCmd.Flags().StringP("title", "t", "", "Pullrequest title")
@@ -334,5 +374,87 @@ func init() {
 	deployPullrequestCmd.Flags().StringP("head-branch-name", "H", "", "Pullrequest head branch name")
 	deployPullrequestCmd.Flags().StringP("head-branch-ref", "M", "", "Pullrequest head branch reference hash")
 	deployPullrequestCmd.Flags().Bool("returndata", false, returnDataUsageText)
+	deployPullrequestCmd.Flags().Bool("follow", false, "Follow the deploy logs")
 	deployPullrequestCmd.Flags().StringArray("buildvar", []string{}, "Add one or more build variables to deployment (--buildvar KEY1=VALUE1 [--buildvar KEY2=VALUE2])")
+}
+
+func followDeployLogs(
+	cmd *cobra.Command,
+	projectName,
+	environmentName,
+	buildName string,
+	debug bool,
+) error {
+	safeEnvName := makeSafe(shortenEnvironment(projectName, environmentName))
+	sshHost, sshPort, username, _, err := getSSHHostPort(safeEnvName, debug)
+	if err != nil {
+		return fmt.Errorf("couldn't get SSH endpoint: %v", err)
+	}
+	ignoreHostKey, acceptNewHostKey :=
+		lagoonssh.CheckStrictHostKey(strictHostKeyCheck)
+	sshConfig, closeSSHAgent, err := getSSHClientConfig(
+		username,
+		fmt.Sprintf("%s:%s", sshHost, sshPort),
+		ignoreHostKey,
+		acceptNewHostKey)
+	if err != nil {
+		return fmt.Errorf("couldn't get SSH client config: %v", err)
+	}
+	defer func() {
+		err = closeSSHAgent()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error closing ssh agent:%v\n", err)
+		}
+	}()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	// start background ticker to close session when deploy completes
+	ticker := time.NewTicker(10 * time.Second)
+	defer ticker.Stop()
+	go func() {
+		defer cancel()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				validateToken(lagoonCLIConfig.Current)
+				current := lagoonCLIConfig.Current
+				token := lagoonCLIConfig.Lagoons[current].Token
+				lc := lclient.New(
+					lagoonCLIConfig.Lagoons[current].GraphQL,
+					lagoonCLIVersion,
+					lagoonCLIConfig.Lagoons[current].Version,
+					&token,
+					debug)
+				// ignore errors here since we can't really do anything about them
+				deployment, _ := lagoon.GetDeploymentByName(
+					ctx, cmdProjectName, cmdProjectEnvironment, buildName, false, lc)
+				if deployment.Completed != "" && deployment.Status != "running" {
+					var status string
+					switch deployment.Status {
+					case "complete":
+						status = "complete ✅"
+					case "failed":
+						status = "failed ❌"
+					case "cancelled":
+						status = "cancelled 🛑"
+					default:
+						status = deployment.Status
+					}
+					fmt.Fprintf(
+						cmd.OutOrStdout(),
+						"Deployment %s finished with status: %s\n",
+						aurora.Yellow(buildName),
+						status)
+					return
+				}
+			}
+		}
+	}()
+	fmt.Fprintf(cmd.OutOrStdout(), "Streaming deploy logs...\n")
+	return lagoonssh.LogStream(ctx, sshConfig, sshHost, sshPort, []string{
+		"lagoonSystem=build",
+		"logs=tailLines=32,follow",
+	})
 }

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -55,6 +55,14 @@ use 'lagoon deploy latest' instead`,
 		if err != nil {
 			return err
 		}
+		showPod, err := cmd.Flags().GetBool("show-pod")
+		if err != nil {
+			return err
+		}
+		showTimestamp, err := cmd.Flags().GetBool("show-timestamp")
+		if err != nil {
+			return err
+		}
 		if err := requiredInputCheck("Project name", cmdProjectName, "Branch name", branch); err != nil {
 			return err
 		}
@@ -95,7 +103,7 @@ use 'lagoon deploy latest' instead`,
 			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 
 			if follow {
-				return followDeployLogs(cmd, cmdProjectName, branch, resultData.Result, debug)
+				return followDeployLogs(cmd, cmdProjectName, branch, resultData.Result, debug, showPod, showTimestamp)
 			}
 		}
 		return nil
@@ -128,6 +136,14 @@ var deployPromoteCmd = &cobra.Command{
 			return err
 		}
 		follow, err := cmd.Flags().GetBool("follow")
+		if err != nil {
+			return err
+		}
+		showPod, err := cmd.Flags().GetBool("show-pod")
+		if err != nil {
+			return err
+		}
+		showTimestamp, err := cmd.Flags().GetBool("show-timestamp")
 		if err != nil {
 			return err
 		}
@@ -168,7 +184,7 @@ var deployPromoteCmd = &cobra.Command{
 			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 
 			if follow {
-				return followDeployLogs(cmd, cmdProjectName, destinationEnvironment, resultData.Result, debug)
+				return followDeployLogs(cmd, cmdProjectName, destinationEnvironment, resultData.Result, debug, showPod, showTimestamp)
 			}
 		}
 		return nil
@@ -196,6 +212,14 @@ This environment should already exist in lagoon. It is analogous with the 'Deplo
 			return err
 		}
 		follow, err := cmd.Flags().GetBool("follow")
+		if err != nil {
+			return err
+		}
+		showPod, err := cmd.Flags().GetBool("show-pod")
+		if err != nil {
+			return err
+		}
+		showTimestamp, err := cmd.Flags().GetBool("show-timestamp")
 		if err != nil {
 			return err
 		}
@@ -239,7 +263,7 @@ This environment should already exist in lagoon. It is analogous with the 'Deplo
 			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 
 			if follow {
-				return followDeployLogs(cmd, cmdProjectName, cmdProjectEnvironment, resultData.Result, debug)
+				return followDeployLogs(cmd, cmdProjectName, cmdProjectEnvironment, resultData.Result, debug, showPod, showTimestamp)
 			}
 		}
 		return nil
@@ -305,6 +329,14 @@ This pullrequest may not already exist as an environment in lagoon.`,
 		if err != nil {
 			return err
 		}
+		showPod, err := cmd.Flags().GetBool("show-pod")
+		if err != nil {
+			return err
+		}
+		showTimestamp, err := cmd.Flags().GetBool("show-timestamp")
+		if err != nil {
+			return err
+		}
 
 		if yesNo(fmt.Sprintf("You are attempting to deploy pull request '%v' for project '%s', are you sure?", prNumber, cmdProjectName)) {
 			current := lagoonCLIConfig.Current
@@ -337,7 +369,7 @@ This pullrequest may not already exist as an environment in lagoon.`,
 			fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
 
 			if follow {
-				return followDeployLogs(cmd, cmdProjectName, fmt.Sprintf("pr-%d", prNumber), resultData.Result, debug)
+				return followDeployLogs(cmd, cmdProjectName, fmt.Sprintf("pr-%d", prNumber), resultData.Result, debug, showPod, showTimestamp)
 			}
 		}
 		return nil
@@ -353,18 +385,24 @@ func init() {
 	const returnDataUsageText = "Returns the build name instead of success text"
 	deployLatestCmd.Flags().Bool("returndata", false, returnDataUsageText)
 	deployLatestCmd.Flags().Bool("follow", false, "Follow the deploy logs")
+	deployLatestCmd.Flags().Bool("show-pod", true, "show pod/container name prefix on log lines")
+	deployLatestCmd.Flags().Bool("show-timestamp", true, "show timestamp prefix on log lines")
 	deployLatestCmd.Flags().StringArray("buildvar", []string{}, "Add one or more build variables to deployment (--buildvar KEY1=VALUE1 [--buildvar KEY2=VALUE2])")
 
 	deployBranchCmd.Flags().StringP("branch", "b", "", "Branch name to deploy")
 	deployBranchCmd.Flags().StringP("branch-ref", "r", "", "Branch ref to deploy")
 	deployBranchCmd.Flags().Bool("returndata", false, returnDataUsageText)
 	deployBranchCmd.Flags().Bool("follow", false, "Follow the deploy logs")
+	deployBranchCmd.Flags().Bool("show-pod", true, "show pod/container name prefix on log lines")
+	deployBranchCmd.Flags().Bool("show-timestamp", true, "show timestamp prefix on log lines")
 	deployBranchCmd.Flags().StringArray("buildvar", []string{}, "Add one or more build variables to deployment (--buildvar KEY1=VALUE1 [--buildvar KEY2=VALUE2])")
 
 	deployPromoteCmd.Flags().StringP("destination", "d", "", "Destination environment name to create")
 	deployPromoteCmd.Flags().StringP("source", "s", "", "Source environment name to use as the base to deploy from")
 	deployPromoteCmd.Flags().Bool("returndata", false, returnDataUsageText)
 	deployPromoteCmd.Flags().Bool("follow", false, "Follow the deploy logs")
+	deployPromoteCmd.Flags().Bool("show-pod", true, "show pod/container name prefix on log lines")
+	deployPromoteCmd.Flags().Bool("show-timestamp", true, "show timestamp prefix on log lines")
 	deployPromoteCmd.Flags().StringArray("buildvar", []string{}, "Add one or more build variables to deployment (--buildvar KEY1=VALUE1 [--buildvar KEY2=VALUE2])")
 
 	deployPullrequestCmd.Flags().StringP("title", "t", "", "Pullrequest title")
@@ -375,6 +413,8 @@ func init() {
 	deployPullrequestCmd.Flags().StringP("head-branch-ref", "M", "", "Pullrequest head branch reference hash")
 	deployPullrequestCmd.Flags().Bool("returndata", false, returnDataUsageText)
 	deployPullrequestCmd.Flags().Bool("follow", false, "Follow the deploy logs")
+	deployPullrequestCmd.Flags().Bool("show-pod", true, "show pod/container name prefix on log lines")
+	deployPullrequestCmd.Flags().Bool("show-timestamp", true, "show timestamp prefix on log lines")
 	deployPullrequestCmd.Flags().StringArray("buildvar", []string{}, "Add one or more build variables to deployment (--buildvar KEY1=VALUE1 [--buildvar KEY2=VALUE2])")
 }
 
@@ -383,7 +423,9 @@ func followDeployLogs(
 	projectName,
 	environmentName,
 	buildName string,
-	debug bool,
+	debug,
+	showPod,
+	showTimestamp bool,
 ) error {
 	safeEnvName := makeSafe(shortenEnvironment(projectName, environmentName))
 	sshHost, sshPort, username, _, err := getSSHHostPort(safeEnvName, debug)
@@ -456,5 +498,5 @@ func followDeployLogs(
 	return lagoonssh.LogStream(ctx, sshConfig, sshHost, sshPort, []string{
 		"lagoonSystem=build",
 		"logs=tailLines=32,follow",
-	})
+	}, showPod, showTimestamp)
 }

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -215,8 +215,10 @@ var logsCmd = &cobra.Command{
 				fmt.Fprintf(os.Stderr, "error closing ssh agent:%v\n", err)
 			}
 		}()
+		ctx, cancel := context.WithCancel(context.TODO())
+		defer cancel()
 		// start SSH log streaming session
-		err = lagoonssh.LogStream(sshConfig, sshHost, sshPort, argv)
+		err = lagoonssh.LogStream(ctx, sshConfig, sshHost, sshPort, argv)
 		if err != nil {
 			output.RenderError(err.Error(), outputOptions)
 			switch e := err.(type) {

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -26,12 +26,14 @@ var (
 	// calls to the Lagoon API.
 	connTimeout = 8 * time.Second
 	// these variables are assigned in init() to flag values
-	logsService   string
-	logsContainer string
-	logsBuild     string
-	logsTask      string
-	logsTailLines uint
-	logsFollow    bool
+	logsService       string
+	logsContainer     string
+	logsBuild         string
+	logsTask          string
+	logsTailLines     uint
+	logsFollow        bool
+	logsShowPod       bool
+	logsShowTimestamp bool
 )
 
 func init() {
@@ -43,6 +45,8 @@ func init() {
 	logsCmd.Flags().Lookup("task").NoOptDefVal = taskNoOptDefVal
 	logsCmd.Flags().UintVarP(&logsTailLines, "lines", "n", 32, "the number of lines to return for each container")
 	logsCmd.Flags().BoolVarP(&logsFollow, "follow", "f", false, "continue outputting new lines as they are logged")
+	logsCmd.Flags().BoolVarP(&logsShowPod, "show-pod", "", true, "show pod/container name prefix on log lines")
+	logsCmd.Flags().BoolVarP(&logsShowTimestamp, "show-timestamp", "", true, "show timestamp prefix on log lines")
 	logsCmd.MarkFlagsMutuallyExclusive("service", "build", "task")
 	logsCmd.MarkFlagsMutuallyExclusive("container", "build", "task")
 }
@@ -218,7 +222,8 @@ var logsCmd = &cobra.Command{
 		ctx, cancel := context.WithCancel(context.TODO())
 		defer cancel()
 		// start SSH log streaming session
-		err = lagoonssh.LogStream(ctx, sshConfig, sshHost, sshPort, argv)
+		err = lagoonssh.LogStream(
+			ctx, sshConfig, sshHost, sshPort, argv, logsShowPod, logsShowTimestamp)
 		if err != nil {
 			output.RenderError(err.Error(), outputOptions)
 			switch e := err.(type) {

--- a/pkg/output/main.go
+++ b/pkg/output/main.go
@@ -66,7 +66,7 @@ func RenderError(errorMsg string, opts Options) {
 		}
 		fmt.Fprintf(os.Stderr, "%s", RenderJSON(jsonData, opts))
 	} else {
-		fmt.Fprintf(os.Stderr, "Error: %s", trimQuotes(errorMsg))
+		fmt.Fprintf(os.Stderr, "Error: %s\n", trimQuotes(errorMsg))
 	}
 }
 

--- a/pkg/output/main_test.go
+++ b/pkg/output/main_test.go
@@ -44,7 +44,7 @@ func TestRenderJSON(t *testing.T) {
 
 func TestRenderError(t *testing.T) {
 	var testData = `Error Message`
-	var testSuccess = `Error: Error Message`
+	var testSuccess = "Error: Error Message\n"
 
 	outputOptions := Options{
 		Header: false,


### PR DESCRIPTION
This change adds support for build and task logs and relies on https://github.com/uselagoon/lagoon-ssh-portal/pull/570.

The `logs` command gets two new flags. The idea is that you can specify `--task` to get logs from all running tasks, or `--task=name` if you know the name.

```
  -b, --build string[="all_builds"]   specify build logs, with an optional specific build name
  -t, --task string[="all_tasks"]     specify task logs, with an optional specific task name
```

The `deploy` subcommands also gets new flags `--follow` that stream deploy logs until the deployment completes.

```
      --follow                 Follow the deploy logs
```

I have no idea if this is a good developer UX: feedback requested.

I have tested this manually using the `deploy latest` subcommand, but have not actually tested the other subcommands because I don't have a good test environment for them. Please let me know if they are broken! In particular, the code relies on the `resultData.Result` being the name of the build. This holds for `deploy latest`, but I don't know if it holds for other subcommands?

```
# tested and working
go run . logs -p test-project -e main --build
go run . logs -p test-project -e main --build=lagoon-build-123xyz
go run . logs -p test-project -e main --task
go run . logs -p test-project -e main --task=lagoon-task-123xyz
go run . deploy latest -p test-project -e main --follow --force

# untested - please test!
go run . deploy branch -p test-project -e main --follow --force
go run . deploy promote -p test-project -e main --follow --force
go run . deploy pullrequest -p test-project -e main --follow --force
```