### PR TITLE
Fix and *RETAIN* version check

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -93,7 +93,7 @@ func isInternetActive() bool {
 func init() {
 	// Add functionality that will be required to run before all commands
 	// These are executed in order.
-	cobra.OnInitialize(initConfig, checkLagoonCliRequiresUpdate)
+	cobra.OnInitialize(initConfig, strictHostKeyCheckInit, checkLagoonCliRequiresUpdate)
 
 	rootCmd.PersistentFlags().StringVarP(&cmdProjectName, "project", "p", "", "Specify a project to use")
 	rootCmd.PersistentFlags().StringVarP(&cmdProjectEnvironment, "environment", "e", "", "Specify an environment to use")
@@ -218,15 +218,20 @@ func initConfig() {
 	}
 }
 
+// strictHostKeyCheckInit sets the strictHostKeyCheck if it's
+// set in the lagoonCLIConfig
+func strictHostKeyCheckInit() {
+	if lagoonCLIConfig.StrictHostKeyChecking != "" {
+		strictHostKeyCheck = lagoonCLIConfig.StrictHostKeyChecking
+	}
+}
+
 // checkLagoonCliRequiresUpdate runs the logic to check
 // the current version of the cli against the most recently
 // released.
 func checkLagoonCliRequiresUpdate() {
 	if lagoonCLIConfig.UpdateCheckDisable {
 		skipUpdateCheck = true
-	}
-	if lagoonCLIConfig.StrictHostKeyChecking != "" {
-		strictHostKeyCheck = lagoonCLIConfig.StrictHostKeyChecking
 	}
 	if !skipUpdateCheck {
 		// Using code from https://github.com/drud/ddev/

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -60,39 +60,6 @@ var rootCmd = &cobra.Command{
 	Short:             "Command line integration for Lagoon",
 	Long:              `Lagoon CLI. Manage your Lagoon hosted projects.`,
 	DisableAutoGenTag: true,
-	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		if lagoonCLIConfig.UpdateCheckDisable {
-			skipUpdateCheck = true
-		}
-		if lagoonCLIConfig.StrictHostKeyChecking != "" {
-			strictHostKeyCheck = lagoonCLIConfig.StrictHostKeyChecking
-		}
-		if !skipUpdateCheck {
-			// Using code from https://github.com/drud/ddev/
-			updateFile := filepath.Join(userPath, ".lagoon.update")
-			// Do periodic detection of whether an update is available for lagoon-cli users.
-			timeToCheckForUpdates, err := updatecheck.IsUpdateNeeded(updateFile, updateInterval)
-			if err != nil {
-				output.RenderInfo(fmt.Sprintf("Could not perform update check %v\n", err), outputOptions)
-			}
-			if timeToCheckForUpdates && isInternetActive() {
-				// Recreate the updatefile with current time so we won't do this again soon.
-				err = updatecheck.ResetUpdateTime(updateFile)
-				if err != nil {
-					output.RenderInfo(fmt.Sprintf("Failed to update updatecheck file %s\n", updateFile), outputOptions)
-				}
-				updateNeeded, updateURL, err := updatecheck.AvailableUpdates("uselagoon", "lagoon-cli", lagoonCLIVersion)
-				if err != nil {
-					output.RenderInfo("Could not check for updates. This is most often caused by a networking issue.\n", outputOptions)
-					output.RenderError(err.Error(), outputOptions)
-					return
-				}
-				if updateNeeded {
-					output.RenderInfo(fmt.Sprintf("A new update is available! please visit %s to download the update.\nFor upgrade help see %s\n\nIf installed using brew, upgrade using `brew upgrade lagoon`\n", updateURL, updateDocURL), outputOptions)
-				}
-			}
-		}
-	},
 	Run: func(cmd *cobra.Command, args []string) {
 		if docsFlag {
 			err := doc.GenMarkdownTree(cmd, "docs/commands")
@@ -124,7 +91,9 @@ func isInternetActive() bool {
 }
 
 func init() {
-	cobra.OnInitialize(initConfig)
+	// Add functionality that will be required to run before all commands
+	// These are executed in order.
+	cobra.OnInitialize(initConfig, checkLagoonCliRequiresUpdate)
 
 	rootCmd.PersistentFlags().StringVarP(&cmdProjectName, "project", "p", "", "Specify a project to use")
 	rootCmd.PersistentFlags().StringVarP(&cmdProjectEnvironment, "environment", "e", "", "Specify an environment to use")
@@ -246,6 +215,43 @@ func initConfig() {
 	}
 	if cmdProject.Environment != "" && cmdProjectEnvironment == "" {
 		cmdProjectEnvironment = cmdProject.Environment
+	}
+}
+
+// checkLagoonCliRequiresUpdate runs the logic to check
+// the current version of the cli against the most recently
+// released.
+func checkLagoonCliRequiresUpdate() {
+	if lagoonCLIConfig.UpdateCheckDisable {
+		skipUpdateCheck = true
+	}
+	if lagoonCLIConfig.StrictHostKeyChecking != "" {
+		strictHostKeyCheck = lagoonCLIConfig.StrictHostKeyChecking
+	}
+	if !skipUpdateCheck {
+		// Using code from https://github.com/drud/ddev/
+		updateFile := filepath.Join(userPath, ".lagoon.update")
+		// Do periodic detection of whether an update is available for lagoon-cli users.
+		timeToCheckForUpdates, err := updatecheck.IsUpdateNeeded(updateFile, updateInterval)
+		if err != nil {
+			output.RenderInfo(fmt.Sprintf("Could not perform update check %v\n", err), outputOptions)
+		}
+		if timeToCheckForUpdates && isInternetActive() {
+			// Recreate the updatefile with current time so we won't do this again soon.
+			err = updatecheck.ResetUpdateTime(updateFile)
+			if err != nil {
+				output.RenderInfo(fmt.Sprintf("Failed to update updatecheck file %s\n", updateFile), outputOptions)
+			}
+			updateNeeded, updateURL, err := updatecheck.AvailableUpdates("uselagoon", "lagoon-cli", lagoonCLIVersion)
+			if err != nil {
+				output.RenderInfo("Could not check for updates. This is most often caused by a networking issue.\n", outputOptions)
+				output.RenderError(err.Error(), outputOptions)
+				return
+			}
+			if updateNeeded {
+				output.RenderInfo(fmt.Sprintf("A new update is available! please visit %s to download the update.\nFor upgrade help see %s\n\nIf installed using brew, upgrade using `brew upgrade lagoon`\n", updateURL, updateDocURL), outputOptions)
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
This PR addresses the logic issue with the overriding of the PersistentPreRun function in the command hierarchy that is leading to the inconsistent running of the version update check across commands.

Here we move this to the cobra OnInitialize() initializer's slice (some discussion on the differences are here, although not particularly useful - https://stackoverflow.com/questions/68766567/oninitialize-vs-persistentprerun-in-a-cobra-based-cli)


# Closing issues

closes #487 

Note - there is a second PR that will remove the functionality except for running in the "version" command explicitly (up to maintainer to choose).