### PR TITLE
Fix and *REMOVE* version check

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -91,7 +91,7 @@ func isInternetActive() bool {
 }
 
 func init() {
-	cobra.OnInitialize(initConfig, StrictHostKeyCheckInit)
+	cobra.OnInitialize(initConfig, strictHostKeyCheckInit)
 
 	rootCmd.PersistentFlags().StringVarP(&cmdProjectName, "project", "p", "", "Specify a project to use")
 	rootCmd.PersistentFlags().StringVarP(&cmdProjectEnvironment, "environment", "e", "", "Specify an environment to use")
@@ -244,7 +244,7 @@ func initConfig() {
 	}
 }
 
-func StrictHostKeyCheckInit() {
+func strictHostKeyCheckInit() {
 	if lagoonCLIConfig.StrictHostKeyChecking != "" {
 		strictHostKeyCheck = lagoonCLIConfig.StrictHostKeyChecking
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -60,39 +60,6 @@ var rootCmd = &cobra.Command{
 	Short:             "Command line integration for Lagoon",
 	Long:              `Lagoon CLI. Manage your Lagoon hosted projects.`,
 	DisableAutoGenTag: true,
-	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		if lagoonCLIConfig.UpdateCheckDisable {
-			skipUpdateCheck = true
-		}
-		if lagoonCLIConfig.StrictHostKeyChecking != "" {
-			strictHostKeyCheck = lagoonCLIConfig.StrictHostKeyChecking
-		}
-		if !skipUpdateCheck {
-			// Using code from https://github.com/drud/ddev/
-			updateFile := filepath.Join(userPath, ".lagoon.update")
-			// Do periodic detection of whether an update is available for lagoon-cli users.
-			timeToCheckForUpdates, err := updatecheck.IsUpdateNeeded(updateFile, updateInterval)
-			if err != nil {
-				output.RenderInfo(fmt.Sprintf("Could not perform update check %v\n", err), outputOptions)
-			}
-			if timeToCheckForUpdates && isInternetActive() {
-				// Recreate the updatefile with current time so we won't do this again soon.
-				err = updatecheck.ResetUpdateTime(updateFile)
-				if err != nil {
-					output.RenderInfo(fmt.Sprintf("Failed to update updatecheck file %s\n", updateFile), outputOptions)
-				}
-				updateNeeded, updateURL, err := updatecheck.AvailableUpdates("uselagoon", "lagoon-cli", lagoonCLIVersion)
-				if err != nil {
-					output.RenderInfo("Could not check for updates. This is most often caused by a networking issue.\n", outputOptions)
-					output.RenderError(err.Error(), outputOptions)
-					return
-				}
-				if updateNeeded {
-					output.RenderInfo(fmt.Sprintf("A new update is available! please visit %s to download the update.\nFor upgrade help see %s\n\nIf installed using brew, upgrade using `brew upgrade lagoon`\n", updateURL, updateDocURL), outputOptions)
-				}
-			}
-		}
-	},
 	Run: func(cmd *cobra.Command, args []string) {
 		if docsFlag {
 			err := doc.GenMarkdownTree(cmd, "docs/commands")
@@ -124,7 +91,7 @@ func isInternetActive() bool {
 }
 
 func init() {
-	cobra.OnInitialize(initConfig)
+	cobra.OnInitialize(initConfig, StrictHostKeyCheckInit)
 
 	rootCmd.PersistentFlags().StringVarP(&cmdProjectName, "project", "p", "", "Specify a project to use")
 	rootCmd.PersistentFlags().StringVarP(&cmdProjectEnvironment, "environment", "e", "", "Specify an environment to use")
@@ -207,6 +174,34 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Version information",
 	Run: func(cmd *cobra.Command, args []string) {
+		if lagoonCLIConfig.UpdateCheckDisable {
+			skipUpdateCheck = true
+		}
+		if !skipUpdateCheck {
+			// Using code from https://github.com/drud/ddev/
+			updateFile := filepath.Join(userPath, ".lagoon.update")
+			// Do periodic detection of whether an update is available for lagoon-cli users.
+			timeToCheckForUpdates, err := updatecheck.IsUpdateNeeded(updateFile, updateInterval)
+			if err != nil {
+				output.RenderInfo(fmt.Sprintf("Could not perform update check %v\n", err), outputOptions)
+			}
+			if timeToCheckForUpdates && isInternetActive() {
+				// Recreate the updatefile with current time so we won't do this again soon.
+				err = updatecheck.ResetUpdateTime(updateFile)
+				if err != nil {
+					output.RenderInfo(fmt.Sprintf("Failed to update updatecheck file %s\n", updateFile), outputOptions)
+				}
+				updateNeeded, updateURL, err := updatecheck.AvailableUpdates("uselagoon", "lagoon-cli", lagoonCLIVersion)
+				if err != nil {
+					output.RenderInfo("Could not check for updates. This is most often caused by a networking issue.\n", outputOptions)
+					output.RenderError(err.Error(), outputOptions)
+					return
+				}
+				if updateNeeded {
+					output.RenderInfo(fmt.Sprintf("A new update is available! please visit %s to download the update.\nFor upgrade help see %s\n\nIf installed using brew, upgrade using `brew upgrade lagoon`\n", updateURL, updateDocURL), outputOptions)
+				}
+			}
+		}
 		displayVersionInfo()
 	},
 }
@@ -246,6 +241,12 @@ func initConfig() {
 	}
 	if cmdProject.Environment != "" && cmdProjectEnvironment == "" {
 		cmdProjectEnvironment = cmdProject.Environment
+	}
+}
+
+func StrictHostKeyCheckInit() {
+	if lagoonCLIConfig.StrictHostKeyChecking != "" {
+		strictHostKeyCheck = lagoonCLIConfig.StrictHostKeyChecking
 	}
 }
 


### PR DESCRIPTION
This is an alternative to #491 

Here we do two things. Move the version update check logic into the version command (the logic seems sound, but we can still remove it wholesale). There was also some non-version check logic in the PersistenPreRun function (namely, the StrictHostCheck details) which I have moved into cobra's initializer's slice (as with the previous version of the PR)


# Closing issues

closes #487 

Note - there is a first PR (#491) that will retain the functionality (up to maintainer to choose).