### PR TITLE
Fixes linting issues with nested Sprintf()s

### DIFF
--- a/cmd/web.go
+++ b/cmd/web.go
@@ -23,7 +23,7 @@ var webCmd = &cobra.Command{
 		urlBuilder := strings.Builder{}
 		urlBuilder.WriteString(lagoonCLIConfig.Lagoons[lagoonCLIConfig.Current].UI)
 		if lagoonCLIConfig.Lagoons[lagoonCLIConfig.Current].UI != "" {
-			urlBuilder.WriteString(fmt.Sprintf("/projects/%s", cmdProjectName))
+			fmt.Fprintf(&urlBuilder,"/projects/%s", cmdProjectName)
 		} else {
 			handleError(fmt.Errorf("unable to determine url for ui, is one set?"))
 		}

--- a/pkg/output/main.go
+++ b/pkg/output/main.go
@@ -89,17 +89,17 @@ func RenderResult(result Result, opts Options) string {
 		return RenderJSON(result, opts)
 	} else {
 		if trimQuotes(result.Result) == "success" {
-			out.WriteString(fmt.Sprintf("Result: %s\n", aurora.Green(trimQuotes(result.Result))))
+			fmt.Fprintf(&out, "Result: %s\n", aurora.Green(trimQuotes(result.Result)))
 			if len(result.ResultData) != 0 {
 				for k, v := range result.ResultData {
-					out.WriteString(fmt.Sprintf("%s: %v\n", k, v))
+					fmt.Fprintf(&out, "%s: %v\n", k, v)
 				}
 			}
 		} else {
-			fmt.Printf("Result: %s\n", aurora.Yellow(trimQuotes(result.Result)))
+			fmt.Fprintf(&out, "Result: %s\n", aurora.Yellow(trimQuotes(result.Result)))
 			if len(result.ResultData) != 0 {
 				for k, v := range result.ResultData {
-					out.WriteString(fmt.Sprintf("%s: %v\n", k, v))
+					fmt.Fprintf(&out, "%s: %v\n", k, v)
 				}
 			}
 		}
@@ -111,7 +111,7 @@ func RenderResult(result Result, opts Options) string {
 func RenderOutput(data Table, opts Options) string {
 	var out bytes.Buffer
 	if opts.Debug {
-		out.WriteString(fmt.Sprintf("%s\n", aurora.Yellow("Final result:")))
+		fmt.Fprintf(&out, "%s\n", aurora.Yellow("Final result:"))
 	}
 	if opts.JSON {
 		// really basic tabledata to json implementation


### PR DESCRIPTION
Working on #491 and #492 - these two are failing with (unrelated) linting errors which seem to have to do with nesting fmt.Sprintf() calls where direct fmt.Fprintf() calls will do.

This should fix these linting issues.

It also, I think, fixes an old time bug (the  `fmt.Printf("Result: %s\n", aurora.Yellow(trimQuotes(result.Result)))` on main.go:99)