### PR TITLE
feat: support adding advanced task definitions to environments

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -36,4 +36,5 @@ func init() {
 	addCmd.AddCommand(addDeployTargetConfigCmd)
 	addCmd.AddCommand(addDeployTargetToOrganizationCmd)
 	addCmd.AddCommand(addAdministratorToOrganizationCmd)
+	addCmd.AddCommand(addAdvancedTaskCmd)
 }

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -853,7 +853,7 @@ var listInvokableTasks = &cobra.Command{
 		}
 
 		data := []output.Data{}
-		for _, task := range tasks.AdvancedTasks {
+		for _, task := range tasks.AdvancedTaskDefinitions {
 			data = append(data, []string{
 				returnNonEmptyString(task.Name),
 				returnNonEmptyString(task.Description),

--- a/cmd/tasks.go
+++ b/cmd/tasks.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/uselagoon/lagoon-cli/pkg/output"
+	"gopkg.in/yaml.v3"
 
 	"github.com/uselagoon/machinery/api/lagoon"
 	lclient "github.com/uselagoon/machinery/api/lagoon/client"
@@ -545,6 +546,112 @@ var uploadFilesToTask = &cobra.Command{
 	},
 }
 
+var addAdvancedTaskCmd = &cobra.Command{
+	Use:     "task",
+	Short:   "Add an advanced task definition to an environment",
+	Long:    `Add an advanced task definition to an environment`,
+	Aliases: []string{"t"},
+	PreRunE: func(_ *cobra.Command, _ []string) error {
+		return validateTokenE(lagoonCLIConfig.Current)
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		var task schema.AdvancedTaskDefinition
+		var (
+			taskName             string
+			taskService          string
+			taskCommand          string
+			taskDescription      string
+			taskConfirmationText string
+		)
+
+		debug, err := cmd.Flags().GetBool("debug")
+		if err != nil {
+			return err
+		}
+
+		if cmd.Flags().Changed("file") {
+			// User has specified a yaml config file for the task definition.
+			filePath, err := cmd.Flags().GetString("file")
+			if err != nil {
+				return err
+			}
+			fileData, err := os.ReadFile(filePath)
+			if err != nil {
+				return err
+			}
+			if err := yaml.Unmarshal(fileData, &task); err != nil {
+				return err
+			}
+		} else { // case where the user uses flags instead of a yaml config file.
+			taskName, err = cmd.Flags().GetString("name")
+			if err != nil {
+				return err
+			}
+			taskService, err = cmd.Flags().GetString("service")
+			if err != nil {
+				return err
+			}
+			taskCommand, err = cmd.Flags().GetString("command")
+			if err != nil {
+				return err
+			}
+			taskDescription, err = cmd.Flags().GetString("description")
+			if err != nil {
+				return err
+			}
+			taskConfirmationText, err = cmd.Flags().GetString("confirmation-text")
+			if err != nil {
+				return err
+			}
+			if err := requiredInputCheck(
+				"Project name", cmdProjectName,
+				"Environment name", cmdProjectEnvironment,
+				"Task command", taskCommand,
+				"Task name", taskName,
+				"Task service", taskService,
+				"Task description", taskDescription,
+			); err != nil {
+				return err
+			}
+			task = schema.AdvancedTaskDefinition{
+				Name:             taskName,
+				Command:          taskCommand,
+				Service:          taskService,
+				Description:      taskDescription,
+				ConfirmationText: taskConfirmationText,
+			}
+		}
+
+		current := lagoonCLIConfig.Current
+		token := lagoonCLIConfig.Lagoons[current].Token
+		lc := lclient.New(
+			lagoonCLIConfig.Lagoons[current].GraphQL,
+			lagoonCLIVersion,
+			lagoonCLIConfig.Lagoons[current].Version,
+			&token,
+			debug)
+
+		environment, err := lagoon.GetEnvironmentByNameAndProjectName(context.TODO(), cmdProjectEnvironment, cmdProjectName, lc)
+		if err != nil {
+			return err
+		}
+
+		taskResult, err := lagoon.AddAdvancedTaskDefinition(context.TODO(), environment.ID, task, lc)
+		if err != nil {
+			return err
+		}
+		resultData := output.Result{
+			Result: "success",
+			ResultData: map[string]interface{}{
+				"id": taskResult.ID,
+			},
+		}
+		r := output.RenderResult(resultData, outputOptions)
+		fmt.Fprintf(cmd.OutOrStdout(), "%s", r)
+		return nil
+	},
+}
+
 func init() {
 	uploadFilesToTask.Flags().IntP("id", "I", 0, "ID of the task")
 	uploadFilesToTask.Flags().StringSliceP("file", "F", []string{}, "File to upload (add multiple flags to upload multiple files)")
@@ -553,4 +660,10 @@ func init() {
 	runCustomTask.Flags().StringP("service", "S", "cli", "Name of the service (cli, nginx, other) that should run the task (default: cli)")
 	runCustomTask.Flags().StringP("command", "c", "", "The command to run in the task")
 	runCustomTask.Flags().StringP("script", "s", "", "Path to bash script to run (will use this before command(-c) if both are defined)")
+	addAdvancedTaskCmd.Flags().StringP("name", "N", "Custom Task", "Name of the task that will show in the UI (default: Custom Task)")
+	addAdvancedTaskCmd.Flags().StringP("service", "S", "cli", "Name of the service (cli, nginx, other) that should run the task (default: cli)")
+	addAdvancedTaskCmd.Flags().StringP("command", "c", "", "The command to run in the task")
+	addAdvancedTaskCmd.Flags().StringP("description", "d", "", "The task description (this is what is displayed in the Lagoon UI)")
+	addAdvancedTaskCmd.Flags().StringP("confirmation-text", "C", "", "The text displayed in the confirmation modal in the Lagoon UI")
+	addAdvancedTaskCmd.Flags().StringP("file", "f", "", "Path to YAML file task definition")
 }

--- a/cmd/tasks.go
+++ b/cmd/tasks.go
@@ -362,7 +362,7 @@ Direct:
 		}
 
 		var taskId uint
-		for _, task := range environment.AdvancedTasks {
+		for _, task := range environment.AdvancedTaskDefinitions {
 			if invokedTaskName == task.Name {
 				taskId = uint(task.ID)
 			}
@@ -547,10 +547,10 @@ var uploadFilesToTask = &cobra.Command{
 }
 
 var addAdvancedTaskCmd = &cobra.Command{
-	Use:     "task",
+	Use:     "task-definition",
 	Short:   "Add an advanced task definition to an environment",
 	Long:    `Add an advanced task definition to an environment`,
-	Aliases: []string{"t"},
+	Aliases: []string{"td"},
 	PreRunE: func(_ *cobra.Command, _ []string) error {
 		return validateTokenE(lagoonCLIConfig.Current)
 	},

--- a/cmd/web.go
+++ b/cmd/web.go
@@ -23,7 +23,7 @@ var webCmd = &cobra.Command{
 		urlBuilder := strings.Builder{}
 		urlBuilder.WriteString(lagoonCLIConfig.Lagoons[lagoonCLIConfig.Current].UI)
 		if lagoonCLIConfig.Lagoons[lagoonCLIConfig.Current].UI != "" {
-			fmt.Fprintf(&urlBuilder,"/projects/%s", cmdProjectName)
+			fmt.Fprintf(&urlBuilder, "/projects/%s", cmdProjectName)
 		} else {
 			handleError(fmt.Errorf("unable to determine url for ui, is one set?"))
 		}


### PR DESCRIPTION
# Description

- Requires https://github.com/uselagoon/machinery/pull/127
- Resolves https://github.com/uselagoon/lagoon-cli/issues/233
- Could continue work to additionally resolve https://github.com/uselagoon/lagoon-cli/issues/262

This PR introduces support for adding `COMMAND`-type advanced task definitions to lagoon environments via the command 
```bash
lagoon add task-definition -p project -e main [-f filepath | -S service -c command -d description -C confirmation]
```

Simple definitions (i.e those with only a command, description, and confirmation text) can be done directly via cli arguments. Otherwise, if the user specifies a file path via the `-f` option, then the cli will read in a task definition defined in a YAML file. The file method is more full-featured, and supports most of the advanced task definition functionality available. For example:

```yaml
name: "example task"
description: "example task"
confirmationText: "Are you sure?"
service: cli
command: "echo $MY_VAR"
permission: DEVELOPER
deployTokenInjection: true
projectKeyInjection: true
adminOnlyView: false
arguments:
  - name: MY_VAR
    displayName: "My Variable"
    type: NUMERIC
    optional: false
    defaultValue: "1122"
``` 

# Limitations

- Doesn't yet support the `IMAGE` task definition type
- At this point in time, only supports defining a task definition on an environment (not project)
